### PR TITLE
[feat] 사용자 정보 조회 및 수정 API를 추가한다

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
@@ -1,0 +1,26 @@
+package org.pickly.service.member.common;
+
+import org.pickly.service.member.controller.request.MemberProfileUpdateReq;
+import org.pickly.service.member.controller.response.MemberProfileRes;
+import org.pickly.service.member.entity.Member;
+import org.pickly.service.member.service.dto.MemberProfileDTO;
+import org.pickly.service.member.service.dto.MemberProfileUpdateDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberMapper {
+
+  public MemberProfileRes toResponse(MemberProfileDTO dto) {
+    return new MemberProfileRes(dto.getName(), dto.getNickname(), dto.getProfileEmoji());
+  }
+
+  public MemberProfileUpdateDTO toDTO(MemberProfileUpdateReq request) {
+    return new MemberProfileUpdateDTO(
+        request.getName(), request.getNickname(), request.getProfileEmoji()
+    );
+  }
+
+  public MemberProfileDTO toMemberProfileDTO(Member member) {
+    return new MemberProfileDTO(member.getName(), member.getNickname(), member.getProfileEmoji());
+  }
+}

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -3,11 +3,14 @@ package org.pickly.service.member.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.pickly.service.member.common.MemberMapper;
 import org.pickly.service.member.controller.request.MemberProfileUpdateReq;
 import org.pickly.service.member.controller.response.MemberProfileRes;
 import org.pickly.service.member.service.interfaces.MemberService;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -19,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/members")
+@Validated
 @Tag(name = "Member", description = "Member API")
 public class MemberController {
 
@@ -30,10 +34,12 @@ public class MemberController {
   public void updateMyProfile(
       // TODO: Replace with member ID from JWT or that from any other authentication method
       @RequestParam
+      @Positive(message = "유저 ID는 양수입니다.")
       @Schema(description = "Member ID (should be replaced later on)", example = "1")
       Long memberId,
 
       @RequestBody
+      @Valid
       MemberProfileUpdateReq request
   ) {
     memberService.updateMyProfile(memberId, memberMapper.toDTO(request));
@@ -43,6 +49,7 @@ public class MemberController {
   @Operation(summary = "Get member profile")
   public MemberProfileRes getMemberProfile(
       @PathVariable
+      @Positive(message = "유저 ID는 양수입니다.")
       @Schema(description = "Member ID", example = "1")
       Long memberId
   ) {

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -1,15 +1,56 @@
 package org.pickly.service.member.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.pickly.service.member.common.MemberMapper;
+import org.pickly.service.member.controller.request.MemberProfileUpdateReq;
+import org.pickly.service.member.controller.response.MemberProfileRes;
 import org.pickly.service.member.service.interfaces.MemberService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/members")
+@Tag(name = "Member", description = "Member API")
 public class MemberController {
 
   private final MemberService memberService;
+  private final MemberMapper memberMapper;
 
+  @PutMapping("/me")
+  @Operation(summary = "Update my profile")
+  public ResponseEntity<Void> updateMyProfile(
+      // TODO: Replace with member ID from JWT or that from any other authentication method
+      @RequestParam(value = "member_id")
+      @Schema(description = "Member ID (should be replaced later on)", example = "1")
+      Long memberId,
+
+      @RequestBody
+      MemberProfileUpdateReq request
+  ) {
+    memberService.updateMyProfile(memberId, memberMapper.toDTO(request));
+    return ResponseEntity.ok().build();
+  }
+
+  @GetMapping("/{nickname}")
+  @Operation(summary = "Get member profile")
+  public ResponseEntity<MemberProfileRes> getMemberProfile(
+      @PathVariable
+      @Schema(description = "Member nickname", example = "pickly")
+      String nickname
+  ) {
+    MemberProfileRes response = memberMapper.toResponse(
+        memberService.findProfileByNickname(nickname)
+    );
+    return ResponseEntity.ok(response);
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -29,7 +29,7 @@ public class MemberController {
   @Operation(summary = "Update my profile")
   public void updateMyProfile(
       // TODO: Replace with member ID from JWT or that from any other authentication method
-      @RequestParam(value = "member_id")
+      @RequestParam
       @Schema(description = "Member ID (should be replaced later on)", example = "1")
       Long memberId,
 

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -8,7 +8,6 @@ import org.pickly.service.member.common.MemberMapper;
 import org.pickly.service.member.controller.request.MemberProfileUpdateReq;
 import org.pickly.service.member.controller.response.MemberProfileRes;
 import org.pickly.service.member.service.interfaces.MemberService;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -28,7 +27,7 @@ public class MemberController {
 
   @PutMapping("/me")
   @Operation(summary = "Update my profile")
-  public ResponseEntity<Void> updateMyProfile(
+  public void updateMyProfile(
       // TODO: Replace with member ID from JWT or that from any other authentication method
       @RequestParam(value = "member_id")
       @Schema(description = "Member ID (should be replaced later on)", example = "1")
@@ -38,19 +37,17 @@ public class MemberController {
       MemberProfileUpdateReq request
   ) {
     memberService.updateMyProfile(memberId, memberMapper.toDTO(request));
-    return ResponseEntity.ok().build();
   }
 
   @GetMapping("/{memberId}")
   @Operation(summary = "Get member profile")
-  public ResponseEntity<MemberProfileRes> getMemberProfile(
+  public MemberProfileRes getMemberProfile(
       @PathVariable
       @Schema(description = "Member ID", example = "1")
       Long memberId
   ) {
-    MemberProfileRes response = memberMapper.toResponse(
+    return memberMapper.toResponse(
         memberService.findProfileByMemberId(memberId)
     );
-    return ResponseEntity.ok(response);
   }
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -41,15 +41,15 @@ public class MemberController {
     return ResponseEntity.ok().build();
   }
 
-  @GetMapping("/{nickname}")
+  @GetMapping("/{memberId}")
   @Operation(summary = "Get member profile")
   public ResponseEntity<MemberProfileRes> getMemberProfile(
       @PathVariable
-      @Schema(description = "Member nickname", example = "pickly")
-      String nickname
+      @Schema(description = "Member ID", example = "1")
+      Long memberId
   ) {
     MemberProfileRes response = memberMapper.toResponse(
-        memberService.findProfileByNickname(nickname)
+        memberService.findProfileByMemberId(memberId)
     );
     return ResponseEntity.ok(response);
   }

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/request/MemberProfileUpdateReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/request/MemberProfileUpdateReq.java
@@ -9,7 +9,12 @@ import lombok.Getter;
 @Schema(description = "Member profile update request")
 public class MemberProfileUpdateReq {
 
+  @Schema(description = "member name", example = "John Doe")
   private String name;
+
+  @Schema(description = "member nickname", example = "johndoe")
   private String nickname;
+
+  @Schema(description = "member profile emoji", example = "👨🏻‍💻")
   private String profileEmoji;
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/request/MemberProfileUpdateReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/request/MemberProfileUpdateReq.java
@@ -1,20 +1,27 @@
 package org.pickly.service.member.controller.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @AllArgsConstructor
 @Schema(description = "Member profile update request")
 public class MemberProfileUpdateReq {
 
+  @NotBlank(message = "사용자 이름을 입력해주세요.")
+  @Length(max = 20, message = "사용자 이름은 20글자 이하로 입력해야 합니다.")
   @Schema(description = "member name", example = "John Doe")
   private String name;
 
+  @NotBlank(message = "사용자 닉네임을 입력해주세요.")
+  @Length(max = 20, message = "사용자 닉네임은 20글자 이하로 입력해야 합니다.")
   @Schema(description = "member nickname", example = "johndoe")
   private String nickname;
 
+  @NotBlank
   @Schema(description = "member profile emoji", example = "👨🏻‍💻")
   private String profileEmoji;
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/request/MemberProfileUpdateReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/request/MemberProfileUpdateReq.java
@@ -1,0 +1,15 @@
+package org.pickly.service.member.controller.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "Member profile update request")
+public class MemberProfileUpdateReq {
+
+  private String name;
+  private String nickname;
+  private String profileEmoji;
+}

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/response/MemberProfileRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/response/MemberProfileRes.java
@@ -1,0 +1,15 @@
+package org.pickly.service.member.controller.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "Member profile response")
+public class MemberProfileRes {
+
+  private String name;
+  private String nickname;
+  private String profileEmoji;
+}

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/response/MemberProfileRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/response/MemberProfileRes.java
@@ -9,7 +9,12 @@ import lombok.Getter;
 @Schema(description = "Member profile response")
 public class MemberProfileRes {
 
+  @Schema(description = "member name", example = "John Doe")
   private String name;
+
+  @Schema(description = "member nickname", example = "johndoe")
   private String nickname;
+
+  @Schema(description = "member profile emoji", example = "👨🏻‍💻")
   private String profileEmoji;
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/dto/controller/CreateMemberReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/dto/controller/CreateMemberReq.java
@@ -1,5 +1,0 @@
-package org.pickly.service.member.dto.controller;
-
-public class CreateMemberReq {
-
-}

--- a/pickly-service/src/main/java/org/pickly/service/member/dto/service/MemberDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/dto/service/MemberDTO.java
@@ -1,5 +1,0 @@
-package org.pickly.service.member.dto.service;
-
-public class MemberDTO {
-
-}

--- a/pickly-service/src/main/java/org/pickly/service/member/entity/Member.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/entity/Member.java
@@ -40,4 +40,9 @@ public class Member extends BaseEntity {
   @Column(name = "profile_emoji", columnDefinition = "text")
   private String profileEmoji;
 
+  public void updateProfile(String name, String nickname, String profileEmoji) {
+    this.name = name;
+    this.nickname = nickname;
+    this.profileEmoji = profileEmoji;
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/repository/interfaces/MemberRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/repository/interfaces/MemberRepository.java
@@ -1,10 +1,8 @@
 package org.pickly.service.member.repository.interfaces;
 
-import java.util.Optional;
 import org.pickly.service.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-  Optional<Member> findOneByNickname(String nickname);
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/repository/interfaces/MemberRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/repository/interfaces/MemberRepository.java
@@ -1,8 +1,10 @@
 package org.pickly.service.member.repository.interfaces;
 
+import java.util.Optional;
 import org.pickly.service.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+  Optional<Member> findOneByNickname(String nickname);
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/dto/MemberProfileDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/dto/MemberProfileDTO.java
@@ -1,0 +1,13 @@
+package org.pickly.service.member.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberProfileDTO {
+
+  private String name;
+  private String nickname;
+  private String profileEmoji;
+}

--- a/pickly-service/src/main/java/org/pickly/service/member/service/dto/MemberProfileUpdateDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/dto/MemberProfileUpdateDTO.java
@@ -1,0 +1,13 @@
+package org.pickly.service.member.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberProfileUpdateDTO {
+
+  private String name;
+  private String nickname;
+  private String profileEmoji;
+}

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -39,8 +39,8 @@ public class MemberServiceImpl implements MemberService {
 
   @Override
   @Transactional(readOnly = true)
-  public MemberProfileDTO findProfileByNickname(String nickname) {
-    Member member = memberRepository.findOneByNickname(nickname)
+  public MemberProfileDTO findProfileByMemberId(Long memberId) {
+    Member member = memberRepository.findById(memberId)
         .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
 
     return memberMapper.toMemberProfileDTO(member);

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -1,21 +1,22 @@
 package org.pickly.service.member.service.impl;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.pickly.common.error.exception.EntityNotFoundException;
+import org.pickly.service.member.common.MemberMapper;
 import org.pickly.service.member.entity.Member;
-import org.pickly.service.member.entity.Password;
 import org.pickly.service.member.repository.interfaces.MemberRepository;
+import org.pickly.service.member.service.dto.MemberProfileDTO;
+import org.pickly.service.member.service.dto.MemberProfileUpdateDTO;
 import org.pickly.service.member.service.interfaces.MemberService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class MemberServiceImpl implements MemberService {
 
   private final MemberRepository memberRepository;
+  private final MemberMapper memberMapper;
 
   @Override
   public void existsById(Long memberId) {
@@ -24,6 +25,28 @@ public class MemberServiceImpl implements MemberService {
     }
   }
 
+  @Transactional
+  public void updateMyProfile(Long memberId, MemberProfileUpdateDTO request) {
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
+
+    member.updateProfile(
+        request.getName(),
+        request.getNickname(),
+        request.getProfileEmoji()
+    );
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public MemberProfileDTO findProfileByNickname(String nickname) {
+    Member member = memberRepository.findOneByNickname(nickname)
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
+
+    return memberMapper.toMemberProfileDTO(member);
+  }
+
+  @Override
   public Member findById(Long id) {
     return memberRepository.findById(id)
         .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 member 입니다."));

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -18,6 +18,11 @@ public class MemberServiceImpl implements MemberService {
   private final MemberRepository memberRepository;
   private final MemberMapper memberMapper;
 
+  private Member findMemberById(Long memberId) {
+    return memberRepository.findById(memberId)
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
+  }
+
   @Override
   public void existsById(Long memberId) {
     if (!memberRepository.existsById(memberId)) {
@@ -27,8 +32,7 @@ public class MemberServiceImpl implements MemberService {
 
   @Transactional
   public void updateMyProfile(Long memberId, MemberProfileUpdateDTO request) {
-    Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
+    Member member = findMemberById(memberId);
 
     member.updateProfile(
         request.getName(),
@@ -40,8 +44,7 @@ public class MemberServiceImpl implements MemberService {
   @Override
   @Transactional(readOnly = true)
   public MemberProfileDTO findProfileByMemberId(Long memberId) {
-    Member member = memberRepository.findById(memberId)
-        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
+    Member member = findMemberById(memberId);
 
     return memberMapper.toMemberProfileDTO(member);
   }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -18,11 +18,6 @@ public class MemberServiceImpl implements MemberService {
   private final MemberRepository memberRepository;
   private final MemberMapper memberMapper;
 
-  private Member findMemberById(Long memberId) {
-    return memberRepository.findById(memberId)
-        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
-  }
-
   @Override
   public void existsById(Long memberId) {
     if (!memberRepository.existsById(memberId)) {
@@ -32,7 +27,7 @@ public class MemberServiceImpl implements MemberService {
 
   @Transactional
   public void updateMyProfile(Long memberId, MemberProfileUpdateDTO request) {
-    Member member = findMemberById(memberId);
+    Member member = findById(memberId);
 
     member.updateProfile(
         request.getName(),
@@ -44,7 +39,7 @@ public class MemberServiceImpl implements MemberService {
   @Override
   @Transactional(readOnly = true)
   public MemberProfileDTO findProfileByMemberId(Long memberId) {
-    Member member = findMemberById(memberId);
+    Member member = findById(memberId);
 
     return memberMapper.toMemberProfileDTO(member);
   }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
@@ -12,5 +12,5 @@ public interface MemberService {
 
   Member findById(Long id);
 
-  MemberProfileDTO findProfileByNickname(String nickname);
+  MemberProfileDTO findProfileByMemberId(Long memberId);
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
@@ -1,12 +1,16 @@
 package org.pickly.service.member.service.interfaces;
 
-import java.util.List;
 import org.pickly.service.member.entity.Member;
+import org.pickly.service.member.service.dto.MemberProfileDTO;
+import org.pickly.service.member.service.dto.MemberProfileUpdateDTO;
 
 public interface MemberService {
 
   void existsById(Long memberId);
 
+  void updateMyProfile(Long memberId, MemberProfileUpdateDTO request);
+
   Member findById(Long id);
 
+  MemberProfileDTO findProfileByNickname(String nickname);
 }

--- a/pickly-service/src/test/groovy/org/pickly/service/member/service/MemberServiceSpec.groovy
+++ b/pickly-service/src/test/groovy/org/pickly/service/member/service/MemberServiceSpec.groovy
@@ -1,0 +1,75 @@
+package org.pickly.service.member.service
+
+import org.junit.jupiter.api.BeforeEach
+import org.pickly.service.member.entity.Member
+import org.pickly.service.member.entity.Password
+import org.pickly.service.member.repository.interfaces.MemberRepository
+import org.pickly.service.member.service.dto.MemberProfileUpdateDTO
+import org.pickly.service.member.service.interfaces.MemberService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import spock.lang.Specification
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class MemberServiceSpec extends Specification {
+
+    @Autowired
+    private MemberService memberService
+
+    @Autowired
+    private MemberRepository memberRepository
+
+    @BeforeEach
+    void setup() {
+        memberRepository.deleteAll()
+    }
+
+    def "사용자 프로필 조회"() {
+        given:
+        var member = memberRepository.save(Member.builder()
+                .email("test@pickly.com")
+                .username("test")
+                .password(new Password("test"))
+                .name("테스트")
+                .nickname("테스트")
+                .profileEmoji("👍")
+                .isHardMode(false)
+                .build())
+
+        when:
+        def dto = memberService.findProfileByMemberId(member.id)
+
+        then:
+        dto != null
+        dto.name == "테스트"
+        dto.nickname == "테스트"
+        dto.profileEmoji == "👍"
+    }
+
+
+    def "사용자 프로필 수정"() {
+        given:
+        var member = memberRepository.save(Member.builder()
+                .email("test@pickly.com")
+                .username("test")
+                .password(new Password("test"))
+                .name("테스트")
+                .nickname("테스트")
+                .profileEmoji("👍")
+                .isHardMode(false)
+                .build())
+
+        when:
+        memberService.updateMyProfile(member.id, new MemberProfileUpdateDTO("수정", "수정", "👎"))
+
+        then:
+        def found = memberRepository.findById(member.id).orElse(null)
+
+        found != null
+        found.name == "수정"
+        found.nickname == "수정"
+        found.profileEmoji == "👎"
+    }
+}


### PR DESCRIPTION
## 📌 개요 (필수)

사용자 정보 조회 및 수정 API를 추가합니다.

수정 API의 경우 사용자 인증 기능이 없으므로 query로 member_id를 받도록 합니다.

Resolves #33.

<br>

## 🔨 작업 사항 (필수)

- `GET /api/members/:nickname`
- `PUT /api/members/me?member_id=:memberId`

[Swagger](http://localhost:8080/swagger-ui/index.html#/)에 접근해 API 문서 확인 가능합니다.

<br>

## ⚡️ 관심 리뷰 (선택)

- 사용자 정보 조회 API는 nickname을 path로 받도록 했으나, id가 좋을지 nickname이 좋을지 아니면 다른게 좋을지 의견 부탁드립니다.

<br>

## 🌱 연관 내용 (선택)

-
