### PR TITLE
[feat] 북마크 좋아요 및 좋아요 해제 API 추가

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/bookmark/controller/BookmarkController.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/controller/BookmarkController.java
@@ -1,15 +1,49 @@
 package org.pickly.service.bookmark.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import org.pickly.service.bookmark.service.interfaces.BookmarkService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/bookmarks")
+
 public class BookmarkController {
 
   private final BookmarkService bookmarkService;
 
+
+  @PutMapping("/{bookmarkId}/like")
+  @Operation(summary = "Like bookmark", description = "Like bookmark")
+
+  // TODO : 멤버 아이디를 토큰에서 가져오도록 수정
+  // 또는 북마크 작업하시는 분이 멤버 아이디를 추가해 주시면 추가할 것
+
+  public ResponseEntity<Void> likeBookmark(
+      @PathVariable
+      @Schema(description = "Bookmark id", example = "1")
+      Long bookmarkId
+  ) {
+    bookmarkService.likeBookmark(bookmarkId);
+    return ResponseEntity.ok().build();
+  }
+
+
+  @DeleteMapping("/{bookmarkId}/like")
+  @Operation(summary = "Unlike bookmark", description = "Unlike bookmark")
+  public ResponseEntity<Void> unlikeBookmark(
+      @PathVariable
+      @Schema(description = "Bookmark id", example = "1")
+      Long bookmarkId
+  ) {
+    bookmarkService.unlikeBookmark(bookmarkId);
+    return ResponseEntity.ok().build();
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/controller/BookmarkController.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/controller/BookmarkController.java
@@ -2,13 +2,15 @@ package org.pickly.service.bookmark.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.pickly.service.bookmark.service.interfaces.BookmarkService;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,30 +21,30 @@ public class BookmarkController {
 
   private final BookmarkService bookmarkService;
 
-
-  @PutMapping("/{bookmarkId}/like")
-  @Operation(summary = "Like bookmark", description = "Like bookmark")
-
   // TODO : 멤버 아이디를 토큰에서 가져오도록 수정
   // 또는 북마크 작업하시는 분이 멤버 아이디를 추가해 주시면 추가할 것
-  public ResponseEntity<Void> likeBookmark(
+  @PostMapping("/{bookmarkId}/like")
+  @ResponseStatus(value = HttpStatus.OK)
+  @Operation(summary = "Like bookmark", description = "Like bookmark")
+  public void likeBookmark(
       @PathVariable
+      @Positive
       @Schema(description = "Bookmark id", example = "1")
       Long bookmarkId
   ) {
     bookmarkService.likeBookmark(bookmarkId);
-    return ResponseEntity.ok().build();
   }
 
 
   @DeleteMapping("/{bookmarkId}/like")
+  @ResponseStatus(value = HttpStatus.OK)
   @Operation(summary = "CancelLike bookmark", description = "CancelLike bookmark")
-  public ResponseEntity<Void> cancelLikeBookmark(
+  public void cancelLikeBookmark(
       @PathVariable
+      @Positive
       @Schema(description = "Bookmark id", example = "1")
       Long bookmarkId
   ) {
     bookmarkService.cancelLikeBookmark(bookmarkId);
-    return ResponseEntity.ok().build();
   }
 }

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/controller/BookmarkController.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/controller/BookmarkController.java
@@ -28,7 +28,7 @@ public class BookmarkController {
   @Operation(summary = "Like bookmark", description = "Like bookmark")
   public void likeBookmark(
       @PathVariable
-      @Positive
+      @Positive(message = "북마크 ID는 양수입니다.")
       @Schema(description = "Bookmark id", example = "1")
       Long bookmarkId
   ) {
@@ -41,7 +41,7 @@ public class BookmarkController {
   @Operation(summary = "CancelLike bookmark", description = "CancelLike bookmark")
   public void cancelLikeBookmark(
       @PathVariable
-      @Positive
+      @Positive(message = "북마크 ID는 양수입니다.")
       @Schema(description = "Bookmark id", example = "1")
       Long bookmarkId
   ) {

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/controller/BookmarkController.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/controller/BookmarkController.java
@@ -25,7 +25,6 @@ public class BookmarkController {
 
   // TODO : 멤버 아이디를 토큰에서 가져오도록 수정
   // 또는 북마크 작업하시는 분이 멤버 아이디를 추가해 주시면 추가할 것
-
   public ResponseEntity<Void> likeBookmark(
       @PathVariable
       @Schema(description = "Bookmark id", example = "1")
@@ -37,13 +36,13 @@ public class BookmarkController {
 
 
   @DeleteMapping("/{bookmarkId}/like")
-  @Operation(summary = "Unlike bookmark", description = "Unlike bookmark")
-  public ResponseEntity<Void> unlikeBookmark(
+  @Operation(summary = "CancelLike bookmark", description = "CancelLike bookmark")
+  public ResponseEntity<Void> cancelLikeBookmark(
       @PathVariable
       @Schema(description = "Bookmark id", example = "1")
       Long bookmarkId
   ) {
-    bookmarkService.unlikeBookmark(bookmarkId);
+    bookmarkService.cancelLikeBookmark(bookmarkId);
     return ResponseEntity.ok().build();
   }
 }

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/entity/Bookmark.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/entity/Bookmark.java
@@ -6,7 +6,6 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -29,14 +28,13 @@ public class Bookmark extends BaseEntity {
   @JoinColumn(name = "category_id")
   private Category category;
 
-  @Lob
-  @Column(nullable = false)
+  @Column(nullable = false, length = 2000)
   private String url;
 
   @Column(length = 100, nullable = false)
   private String title;
 
-  @Lob
+
   @Column(name = "preview_image_url")
   private String previewImageUrl;
 
@@ -47,4 +45,11 @@ public class Bookmark extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private Visibility visibility;
 
+  public void updateUserLike() {
+    this.isUserLike = true;
+  }
+
+  public void updateUserUnlike() {
+    this.isUserLike = false;
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/entity/Bookmark.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/entity/Bookmark.java
@@ -45,11 +45,11 @@ public class Bookmark extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private Visibility visibility;
 
-  public void updateUserLike() {
+  public void like() {
     this.isUserLike = true;
   }
 
-  public void updateUserCancelLike() {
+  public void deleteLike() {
     this.isUserLike = false;
   }
 }

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/entity/Bookmark.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/entity/Bookmark.java
@@ -49,7 +49,7 @@ public class Bookmark extends BaseEntity {
     this.isUserLike = true;
   }
 
-  public void updateUserUnlike() {
+  public void updateUserCancelLike() {
     this.isUserLike = false;
   }
 }

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/repository/interfaces/BookmarkRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/repository/interfaces/BookmarkRepository.java
@@ -1,8 +1,10 @@
 package org.pickly.service.bookmark.repository.interfaces;
 
+import java.util.Optional;
 import org.pickly.service.bookmark.entity.Bookmark;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
+  Optional<Bookmark> findOneById(Long id);
 }

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/service/impl/BookmarkServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/service/impl/BookmarkServiceImpl.java
@@ -1,6 +1,8 @@
 package org.pickly.service.bookmark.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.pickly.common.error.exception.EntityNotFoundException;
+import org.pickly.service.bookmark.entity.Bookmark;
 import org.pickly.service.bookmark.repository.interfaces.BookmarkRepository;
 import org.pickly.service.bookmark.service.interfaces.BookmarkService;
 import org.springframework.stereotype.Service;
@@ -9,9 +11,25 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class BookmarkServiceImpl implements BookmarkService {
 
   private final BookmarkRepository bookmarkRepository;
 
+
+  @Override
+  @Transactional
+  public void likeBookmark(Long bookmarkId) {
+    Bookmark bookmark = bookmarkRepository.findOneById(bookmarkId)
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 북마크입니다."));
+
+    bookmark.updateUserLike();
+  }
+
+  @Override
+  public void unlikeBookmark(Long bookmarkId) {
+    Bookmark bookmark = bookmarkRepository.findOneById(bookmarkId)
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 북마크입니다."));
+
+    bookmark.updateUserUnlike();
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/service/impl/BookmarkServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/service/impl/BookmarkServiceImpl.java
@@ -6,7 +6,6 @@ import org.pickly.service.bookmark.entity.Bookmark;
 import org.pickly.service.bookmark.repository.interfaces.BookmarkRepository;
 import org.pickly.service.bookmark.service.interfaces.BookmarkService;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
@@ -17,7 +16,6 @@ public class BookmarkServiceImpl implements BookmarkService {
 
 
   @Override
-  @Transactional
   public void likeBookmark(Long bookmarkId) {
     Bookmark bookmark = bookmarkRepository.findOneById(bookmarkId)
         .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 북마크입니다."));
@@ -26,10 +24,10 @@ public class BookmarkServiceImpl implements BookmarkService {
   }
 
   @Override
-  public void unlikeBookmark(Long bookmarkId) {
+  public void cancelLikeBookmark(Long bookmarkId) {
     Bookmark bookmark = bookmarkRepository.findOneById(bookmarkId)
         .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 북마크입니다."));
 
-    bookmark.updateUserUnlike();
+    bookmark.updateUserCancelLike();
   }
 }

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/service/impl/BookmarkServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/service/impl/BookmarkServiceImpl.java
@@ -14,20 +14,21 @@ public class BookmarkServiceImpl implements BookmarkService {
 
   private final BookmarkRepository bookmarkRepository;
 
+  @Override
+  public Bookmark findById(Long Id) {
+    return bookmarkRepository.findOneById(Id)
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 북마크입니다."));
+  }
 
   @Override
   public void likeBookmark(Long bookmarkId) {
-    Bookmark bookmark = bookmarkRepository.findOneById(bookmarkId)
-        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 북마크입니다."));
-
-    bookmark.updateUserLike();
+    Bookmark bookmark = findById(bookmarkId);
+    bookmark.like();
   }
 
   @Override
   public void cancelLikeBookmark(Long bookmarkId) {
-    Bookmark bookmark = bookmarkRepository.findOneById(bookmarkId)
-        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 북마크입니다."));
-
-    bookmark.updateUserCancelLike();
+    Bookmark bookmark = findById(bookmarkId);
+    bookmark.deleteLike();
   }
 }

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/service/interfaces/BookmarkService.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/service/interfaces/BookmarkService.java
@@ -1,5 +1,10 @@
 package org.pickly.service.bookmark.service.interfaces;
 
+
 public interface BookmarkService {
+
+  void likeBookmark(Long memberId);
+
+  void unlikeBookmark(Long memberId);
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/service/interfaces/BookmarkService.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/service/interfaces/BookmarkService.java
@@ -1,10 +1,13 @@
 package org.pickly.service.bookmark.service.interfaces;
 
 
+import org.pickly.service.bookmark.entity.Bookmark;
+
 public interface BookmarkService {
+
+  Bookmark findById(Long Id);
 
   void likeBookmark(Long memberId);
 
   void cancelLikeBookmark(Long memberId);
-
 }

--- a/pickly-service/src/main/java/org/pickly/service/bookmark/service/interfaces/BookmarkService.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/service/interfaces/BookmarkService.java
@@ -5,6 +5,6 @@ public interface BookmarkService {
 
   void likeBookmark(Long memberId);
 
-  void unlikeBookmark(Long memberId);
+  void cancelLikeBookmark(Long memberId);
 
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #36 

- [x] 북마크 좋아요
- [x] 북마크 좋아요 해제

<br>

## 🔨 작업 사항 (필수)

- PUT /api/bookmarks/:bookmarkId/like
- DELETE /api/bookmarks/:bookmarkId/like

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

### 1. 
bookmark entity에 다음과 같이 url 길이를 2000자 제한을 추가 했는데
괜찮은 방법일지에 대해서 궁금 합니다.
```java
  @Column(nullable = false, length = 2000)
```
### 2.

- [#30 Postgres @Lob (text type) 이슈](https://github.com/pickly-team/pickly-backend/issues/30) 내용에 대해서 처리를 했는데 확인해 주시면 감사하겠습니다 🙇‍♂️

### 3.

유저가 좋아요, 좋아요 해제 요청을 보낼 시 게시글 작성자와 API 요청자가 같은 유저인지 판별을 해야할 것 같은데
현재 Entity에 memberId가 존재하지 않아서 일단 제외 시켜 두었습니다.
토큰으로 검사하는 이외에도 API 요청에서 memberId를 추가시켜야겠죠? 

<br>

## 🌱 연관 내용 (선택)

- #30 Postgres @Lob (text type) 이슈
