### PR TITLE
[feat] 친구 팔로우 & 언팔로우

### DIFF
--- a/pickly-common/src/main/java/org/pickly/common/error/exception/ErrorCode.java
+++ b/pickly-common/src/main/java/org/pickly/common/error/exception/ErrorCode.java
@@ -10,9 +10,10 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(400, "C001", " Invalid Input Value"),
     METHOD_NOT_ALLOWED(405, "C002", " Invalid Input Value"),
     ENTITY_NOT_FOUND(400, "C003", " Entity Not Found"),
-    INTERNAL_SERVER_ERROR(500, "C004", "Server Error"),
-    INVALID_TYPE_VALUE(400, "C005", " Invalid Type Value"),
-    HANDLE_ACCESS_DENIED(403, "C006", "Access is Denied");
+    ENTITY_CONFLICT(409, "C004", "Entity Already Exist"),
+    INTERNAL_SERVER_ERROR(500, "C005", "Server Error"),
+    INVALID_TYPE_VALUE(400, "C006", " Invalid Type Value"),
+    HANDLE_ACCESS_DENIED(403, "C007", "Access is Denied");
 
     private final String code;
     private final String message;

--- a/pickly-service/src/main/java/org/pickly/service/friend/controller/FriendController.java
+++ b/pickly-service/src/main/java/org/pickly/service/friend/controller/FriendController.java
@@ -1,15 +1,47 @@
 package org.pickly.service.friend.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.pickly.service.friend.service.interfaces.FriendService;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api")
 public class FriendController {
 
   private final FriendService friendService;
+
+  // TODO: JWT 개발 후 followerId를 삭제 예정
+  @PostMapping("/members/{followerId}/following/{memberId}")
+  @Operation(summary = "특정 멤버 팔로우")
+  public void follow(
+      @Parameter(name = "followerId", description = "팔로우 요청을 보낸 유저 ID 값", example = "1", required = true)
+      @Positive(message = "유저 ID는 양수입니다.") @PathVariable final Long followerId,
+
+      @Parameter(name = "memberId", description = "팔로우 할 유저 ID 값", example = "3", required = true)
+      @Positive(message = "유저 ID는 양수입니다.") @PathVariable final Long memberId
+  ) {
+    friendService.follow(followerId, memberId);
+  }
+
+  // TODO: JWT 개발 후 followerId를 삭제 예정
+  @DeleteMapping("/members/{followerId}/following/{memberId}")
+  @Operation(summary = "특정 멤버 언팔로우")
+  public void unfollow(
+      @Parameter(name = "followerId", description = "언팔로우 요청을 보낸 유저 ID 값", example = "1", required = true)
+      @Positive(message = "유저 ID는 양수입니다.") @PathVariable final Long followerId,
+
+      @Parameter(name = "memberId", description = "언팔로우 할 유저 ID 값", example = "3", required = true)
+      @Positive(message = "유저 ID는 양수입니다.") @PathVariable final Long memberId
+  ) {
+    friendService.unfollow(followerId, memberId);
+  }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/friend/repository/interfaces/FriendRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/friend/repository/interfaces/FriendRepository.java
@@ -2,7 +2,16 @@ package org.pickly.service.friend.repository.interfaces;
 
 import org.pickly.service.friend.entity.Friend;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FriendRepository extends JpaRepository<Friend, Long> {
+
+  @Modifying
+  @Query("delete from Friend f where f.followee.id = :memberId and f.follower.id = :followerId")
+  void unfollow(@Param("followerId") Long followerId, @Param("memberId") Long memberId);
+
+  boolean existsByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/friend/service/impl/FriendServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/friend/service/impl/FriendServiceImpl.java
@@ -1,7 +1,13 @@
 package org.pickly.service.friend.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.pickly.common.error.exception.BusinessException;
+import org.pickly.common.error.exception.ErrorCode;
+import org.pickly.service.friend.entity.Friend;
+import org.pickly.service.friend.repository.interfaces.FriendRepository;
 import org.pickly.service.friend.service.interfaces.FriendService;
+import org.pickly.service.member.entity.Member;
+import org.pickly.service.member.service.interfaces.MemberService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,5 +15,29 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class FriendServiceImpl implements FriendService {
+
+  private final FriendRepository friendRepository;
+  private final MemberService memberService;
+
+  @Override
+  @Transactional
+  public void follow(final Long followerId, final Long memberId) {
+    checkAlreadyFriend(followerId, memberId);
+    Member follower = memberService.findById(followerId);
+    Member followee = memberService.findById(memberId);
+    friendRepository.save(new Friend(followee, follower));
+  }
+
+  @Override
+  @Transactional
+  public void unfollow(final Long followerId, final Long memberId) {
+    friendRepository.unfollow(followerId, memberId);
+  }
+
+  private void checkAlreadyFriend(final Long followerId, final Long memberId) {
+    if (friendRepository.existsByFollowerIdAndFolloweeId(followerId, memberId)) {
+      throw new BusinessException(ErrorCode.ENTITY_CONFLICT);
+    }
+  }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/friend/service/interfaces/FriendService.java
+++ b/pickly-service/src/main/java/org/pickly/service/friend/service/interfaces/FriendService.java
@@ -2,4 +2,8 @@ package org.pickly.service.friend.service.interfaces;
 
 public interface FriendService {
 
+  void follow(Long followerId, Long memberId);
+
+  void unfollow(Long followerId, Long memberId);
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -2,11 +2,11 @@ package org.pickly.service.member.service.impl;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.pickly.common.error.exception.EntityNotFoundException;
 import org.pickly.service.member.entity.Member;
 import org.pickly.service.member.entity.Password;
 import org.pickly.service.member.repository.interfaces.MemberRepository;
 import org.pickly.service.member.service.interfaces.MemberService;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,4 +37,11 @@ public class MemberServiceImpl implements MemberService {
         .build();
     return memberRepository.save(member);
   }
+
+  @Override
+  public Member findById(Long id) {
+    return memberRepository.findById(id)
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 member 입니다."));
+  }
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
@@ -9,4 +9,6 @@ public interface MemberService {
 
   Member save(String username);
 
+  Member findById(Long id);
+
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #39 
- 멤버 팔로우, 언팔로우 기능

<br>

## 🔨 작업 사항 (필수)

- 특정 멤버 팔로우
- 특정 멤버 언팔로우

<br>

## ⚡️ 관심 리뷰 (선택)

- 이미 친구인데 또 팔로우을 보내는 경우엔 DB에 중복 데이터가 쌓이니까, 이미 친구인지 확인하는 코드를 넣어줬습니다.
- 근데 친구가 아닌데 언팔로우 요청을 보내는 경우엔, 그냥 아무것도 delete되지 않은 상태로 종료가 될 테니 서비스 오류는 아니라서요🤔 따라서 친구인지 확인하는 로직을 넣지 않았는데, 이에 대해 어떻게 생각하시는지 궁금합니다! 

<br>

## 🌱 연관 내용 (선택)

- JWT 구현 후 followerId는 전부 accessToken에서 꺼내오는 방식으로 변경할 예정입니다.
- [Custom Error Response 작업 후](https://github.com/pickly-team/pickly-backend/issues/32) throw Exception 부분 전부 변경할 예정입니다. (지금은 예시로 넣어둔 exception 사용했어요!)
