### PR TITLE
[feat]: 비밀번호 변경 API를 추가합니다.

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.pickly.service.member.common.MemberMapper;
+import org.pickly.service.member.controller.request.MemberChangePasswordReq;
 import org.pickly.service.member.controller.request.MemberProfileUpdateReq;
 import org.pickly.service.member.controller.response.MemberProfileRes;
 import org.pickly.service.member.service.interfaces.MemberService;
@@ -28,6 +29,22 @@ public class MemberController {
 
   private final MemberService memberService;
   private final MemberMapper memberMapper;
+
+  @PutMapping("/password")
+  @Operation(summary = "Change password")
+  public void changePassword(
+      // TODO: Replace with member ID from JWT or that from any other authentication method
+      @RequestParam
+      @Positive(message = "유저 ID는 양수입니다.")
+      @Schema(description = "Member ID (should be replaced later on)", example = "1")
+      Long memberId,
+
+      @RequestBody
+      @Valid
+      MemberChangePasswordReq request
+  ) {
+    memberService.changePassword(memberId, request.getCurrentPassword(), request.getNewPassword());
+  }
 
   @PutMapping("/me")
   @Operation(summary = "Update my profile")

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/request/MemberChangePasswordReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/request/MemberChangePasswordReq.java
@@ -1,0 +1,26 @@
+package org.pickly.service.member.controller.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "Member password change request")
+public class MemberChangePasswordReq {
+
+  @NotNull(message = "현재 비밀번호를 입력해주세요.")
+  @Schema(description = "current password", example = "currentPassword")
+  private String currentPassword;
+
+  @NotBlank(message = "새 비밀번호를 입력해주세요.")
+  @Length(min = 8, max = 32, message = "새 비밀번호는 8자 이상 32자 이하로 입력해야 합니다.")
+  @Schema(description = "new password", example = "newPassword")
+  @Pattern(regexp = "^(?=.*[0-9])(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=\\S+$).{8,32}$",
+      message = "새 비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
+  private String newPassword;
+}

--- a/pickly-service/src/main/java/org/pickly/service/member/entity/Member.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/entity/Member.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.pickly.common.error.exception.InvalidValueException;
 import org.pickly.service.common.utils.base.BaseEntity;
 
 @Entity
@@ -44,5 +45,15 @@ public class Member extends BaseEntity {
     this.name = name;
     this.nickname = nickname;
     this.profileEmoji = profileEmoji;
+  }
+
+  public void changePassword(String currentPassword, String newPassword) {
+    if (!password.isMatched(currentPassword)) {
+      throw new InvalidValueException("현재 비밀번호가 일치하지 않습니다.");
+    }
+    if (password.isMatched(newPassword)) {
+      throw new InvalidValueException("현재 비밀번호와 동일합니다.");
+    }
+    password.update(newPassword);
   }
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -25,6 +25,18 @@ public class MemberServiceImpl implements MemberService {
     }
   }
 
+  @Override
+  @Transactional
+  public void changePassword(
+      Long memberId,
+      String currentPassword,
+      String newPassword
+  ) {
+    Member member = findById(memberId);
+
+    member.changePassword(currentPassword, newPassword);
+  }
+
   @Transactional
   public void updateMyProfile(Long memberId, MemberProfileUpdateDTO request) {
     Member member = findById(memberId);

--- a/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
@@ -8,6 +8,8 @@ public interface MemberService {
 
   void existsById(Long memberId);
 
+  void changePassword(Long memberId, String currentPassword, String newPassword);
+
   void updateMyProfile(Long memberId, MemberProfileUpdateDTO request);
 
   Member findById(Long id);

--- a/pickly-service/src/test/groovy/org/pickly/service/member/service/MemberServiceSpec.groovy
+++ b/pickly-service/src/test/groovy/org/pickly/service/member/service/MemberServiceSpec.groovy
@@ -1,6 +1,8 @@
 package org.pickly.service.member.service
 
 import org.junit.jupiter.api.BeforeEach
+import org.pickly.common.error.exception.InvalidValueException
+import org.pickly.service.member.MemberFactory
 import org.pickly.service.member.entity.Member
 import org.pickly.service.member.entity.Password
 import org.pickly.service.member.repository.interfaces.MemberRepository
@@ -14,6 +16,8 @@ import spock.lang.Specification
 @SpringBootTest
 @AutoConfigureMockMvc
 class MemberServiceSpec extends Specification {
+
+    private final MemberFactory memberFactory = new MemberFactory()
 
     @Autowired
     private MemberService memberService
@@ -71,5 +75,41 @@ class MemberServiceSpec extends Specification {
         found.name == "수정"
         found.nickname == "수정"
         found.profileEmoji == "👎"
+    }
+
+    def "비밀번호 변경 - 성공"() {
+        given:
+        var member = memberFactory.testMember()
+        memberRepository.save(member)
+
+        when:
+        memberService.changePassword(member.id, "nobodyKnows123", "test")
+
+        then:
+        noExceptionThrown()
+    }
+
+    def "비밀번호 변경 - 기존 비밀번호를 틀린 경우 예외 발생"() {
+        given:
+        var member = memberFactory.testMember()
+        memberRepository.save(member)
+
+        when:
+        memberService.changePassword(member.id, "test", "test")
+
+        then:
+        thrown InvalidValueException
+    }
+
+    def "비밀번호 변경 - 기존 비밀번호가 새로운 비밀번호와 같은 경우 예외 발생"() {
+        given:
+        var member = memberFactory.testMember()
+        memberRepository.save(member)
+
+        when:
+        memberService.changePassword(member.id, "nobodyKnows123", "nobodyKnows123")
+
+        then:
+        thrown InvalidValueException
     }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

비밀번호 변경 API를 추가합니다.

Resolves #53.

<br>

## 🔨 작업 사항 (필수)

비밀번호 변경 API를 추가합니다:

`PUT /api/members/password`

Request Body

- `currentPassword: string` - 기존 비밀번호 (not null)
- `newPassword: string` - 새 비밀번호 (not blank, 8~32자, 영문, 숫자, 특수문자 포함)

Response

- 200 OK

<br>

## ⚡️ 관심 리뷰 (선택)

X

<br>

## 🌱 연관 내용 (선택)

- #35 와 연관이 있습니다.
