### PR TITLE
[feat] Category 도메인 CRUD 로직을 생성한다

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
@@ -1,10 +1,17 @@
 package org.pickly.service.category.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
-import version.VersionResource;
+import org.pickly.service.category.dto.controller.CategoryCreateReq;
+import org.pickly.service.category.dto.controller.CategoryUpdateReq;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.pickly.service.category.service.interfaces.CategoryService;
-import org.pickly.service.common.version.ApiVersion;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -15,10 +22,18 @@ public class CategoryController {
 
   private final CategoryService categoryService;
 
-  @GetMapping("/test")
-  @VersionResource(from = ApiVersion.V1)
-  public String test() {
-    return "test";
-  }
+  @Operation(summary = "카테고리 생성 요청")
+  @PostMapping("/members/{memberId}/categories")
+  public void createCategory(
+      @PathVariable
+      @Positive(message = "유저 ID는 양수입니다.")
+      @Schema(description = "Member ID", example = "1")
+      Long memberId,
 
+      @Valid @RequestBody
+      @Schema(description = "Category Name", example = "내일 안으로 꼭 봐야할 자바 면접 질문")
+      CategoryCreateReq request
+  ) {
+    categoryService.create(memberId, request);
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
@@ -36,4 +36,23 @@ public class CategoryController {
   ) {
     categoryService.create(memberId, request);
   }
+
+  @Operation(summary = "카테고리 수정 요청")
+  @PutMapping("/members/{memberId}/categories/{categoryId}")
+  public void updateCategory(
+      @PathVariable
+      @Positive(message = "유저 ID는 양수입니다.")
+      @Schema(description = "Member ID", example = "1")
+      Long memberId,
+
+      @PathVariable
+      @Positive(message = "카테고리 ID는 양수입니다.")
+      @Schema(description = "Category ID", example = "1")
+      Long categoryId,
+
+      @Valid @RequestBody
+      CategoryUpdateReq request
+  ) {
+    categoryService.update(memberId, categoryId, request);
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryCreateReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryCreateReq.java
@@ -1,0 +1,14 @@
+package org.pickly.service.category.dto.controller;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "Category create request")
+public class CategoryCreateReq {
+  @NotBlank(message = "카테고리 이름을 입력해주세요.")
+  private String categoryName;
+}

--- a/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryUpdateReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryUpdateReq.java
@@ -1,0 +1,24 @@
+package org.pickly.service.category.dto.controller;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "Category update request")
+public class CategoryUpdateReq {
+  @NotNull
+  @Schema(description = "자동 삭제 기능 여부", example = "true")
+  private Boolean isAutoDeleteMode;
+
+  @NotBlank(message = "카테고리 이름을 입력해주세요.")
+  @Schema(description = "category name", example = "카테고리 이름")
+  private String categoryName;
+
+  @NotBlank(message = "카테고리 이모지를 입력해주세요.")
+  @Schema(description = "category emoji", example = "📚")
+  private String emoji;
+}

--- a/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CreateCategoryReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CreateCategoryReq.java
@@ -1,5 +1,0 @@
-package org.pickly.service.category.dto.controller;
-
-public class CreateCategoryReq {
-
-}

--- a/pickly-service/src/main/java/org/pickly/service/category/entity/Category.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/entity/Category.java
@@ -35,4 +35,14 @@ public class Category extends BaseEntity {
   @Column(columnDefinition = "text")
   private String emoji;
 
+  public Category(Member member, String name) {
+    this(member, false, name, "🥒");
+  }
+
+
+  public void update(Boolean isAutoDeleteMode, String name, String emoji) {
+    this.isAutoDeleteMode = isAutoDeleteMode;
+    this.name = name;
+    this.emoji = emoji;
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/category/entity/Category.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/entity/Category.java
@@ -39,7 +39,6 @@ public class Category extends BaseEntity {
     this(member, false, name, "🥒");
   }
 
-
   public void update(Boolean isAutoDeleteMode, String name, String emoji) {
     this.isAutoDeleteMode = isAutoDeleteMode;
     this.name = name;

--- a/pickly-service/src/main/java/org/pickly/service/category/service/impl/CategoryServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/service/impl/CategoryServiceImpl.java
@@ -25,4 +25,12 @@ public class CategoryServiceImpl implements CategoryService {
     Category category = new Category(memberService.findById(memberId), request.getCategoryName());
     categoryRepository.save(category);
   }
+
+  @Transactional
+  public void update(Long memberId, Long categoryId, CategoryUpdateReq request) {
+    Category category = categoryRepository.findById(categoryId)
+        .orElseThrow(() -> new EntityNotFoundException("요청하신 카테고리가 존재하지 않습니다."));
+
+    category.update(request.getIsAutoDeleteMode(), request.getCategoryName(), request.getEmoji());
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/category/service/impl/CategoryServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/service/impl/CategoryServiceImpl.java
@@ -1,8 +1,13 @@
 package org.pickly.service.category.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.pickly.common.error.exception.EntityNotFoundException;
+import org.pickly.service.category.dto.controller.CategoryCreateReq;
+import org.pickly.service.category.dto.controller.CategoryUpdateReq;
+import org.pickly.service.category.entity.Category;
 import org.pickly.service.category.repository.interfaces.CategoryRepository;
 import org.pickly.service.category.service.interfaces.CategoryService;
+import org.pickly.service.member.service.interfaces.MemberService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -13,4 +18,11 @@ public class CategoryServiceImpl implements CategoryService {
 
   private final CategoryRepository categoryRepository;
 
+  private final MemberService memberService;
+
+  @Transactional
+  public void create(Long memberId, CategoryCreateReq request) {
+    Category category = new Category(memberService.findById(memberId), request.getCategoryName());
+    categoryRepository.save(category);
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/category/service/interfaces/CategoryService.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/service/interfaces/CategoryService.java
@@ -1,5 +1,8 @@
 package org.pickly.service.category.service.interfaces;
 
+import org.pickly.service.category.dto.controller.CategoryCreateReq;
+
 public interface CategoryService {
 
+  void create(Long memberId, CategoryCreateReq categoryName);
 }

--- a/pickly-service/src/main/java/org/pickly/service/category/service/interfaces/CategoryService.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/service/interfaces/CategoryService.java
@@ -1,8 +1,10 @@
 package org.pickly.service.category.service.interfaces;
 
 import org.pickly.service.category.dto.controller.CategoryCreateReq;
+import org.pickly.service.category.dto.controller.CategoryUpdateReq;
 
 public interface CategoryService {
 
   void create(Long memberId, CategoryCreateReq categoryName);
+  void update(Long memberId, Long categoryId, CategoryUpdateReq request);
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #20 
- PR의 메인 내용 : 카테고리 생성, 수정 기능을 구현합니다.

<br>

## 🔨 작업 사항 (필수)

- 카테고리 생성, 수정 기능을 구현합니다.

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- Service, Repository를 interface로 추상화한 이유가 뭔가요?? 추상화를 하려면 공통된 부분들이 있어야 하는데 공통 부분이 없는데 우선 추상화한 것이 잘 와닿지 않아서요
- 우선 Update 부분은 우선 PUT으로 구현했으나, 추후 유의미한 트래픽 발생하며 성능 이슈가 발생한다면 분할해서 PATCH로 구현하는 게 좋을 것 같습니다.