### PR TITLE
[setting] p6spy 로그 설정 추가

### DIFF
--- a/pickly-service/build.gradle
+++ b/pickly-service/build.gradle
@@ -27,6 +27,9 @@ dependencies {
     // graphql
     implementation 'org.springframework.boot:spring-boot-starter-graphql'
 
+    // p6spy
+    implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.8.0'
+
     runtimeOnly 'org.postgresql:postgresql:42.5.3'
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/pickly-service/src/main/java/org/pickly/service/common/utils/logger/P6SpySqlFormatter.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/utils/logger/P6SpySqlFormatter.java
@@ -1,0 +1,55 @@
+package org.pickly.service.common.utils.logger;
+
+import com.p6spy.engine.logging.Category;
+import com.p6spy.engine.spy.P6SpyOptions;
+import com.p6spy.engine.spy.appender.MessageFormattingStrategy;
+import jakarta.annotation.PostConstruct;
+import java.util.ArrayDeque;
+import org.hibernate.engine.jdbc.internal.FormatStyle;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class P6SpySqlFormatter implements MessageFormattingStrategy {
+
+  private static String PACKAGE = "org.pickly.service";
+  private static String P6SPY_PACKAGE = "P6SpySqlFormatter";
+
+  @PostConstruct
+  public void setLogMessageFormat() {
+    P6SpyOptions.getActiveInstance().setLogMessageFormat(this.getClass().getName());
+  }
+
+  @Override
+  public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared,
+      String sql, String url) {
+    sql = formatSql(category, sql);
+    return String.format("[%s] | %d ms | %s | %s", category, elapsed, createStack(), formatSql(category, sql));
+  }
+
+  private String formatSql(String category, String sql) {
+    if (sql != null && !sql.trim().isEmpty() && Category.STATEMENT.getName().equals(category)) {
+      return FormatStyle.BASIC.getFormatter().format(sql);
+    }
+    return sql;
+  }
+
+  private String createStack() {
+    ArrayDeque<String> callStack = new ArrayDeque<>();
+    StackTraceElement[] stackTrace = new Throwable().getStackTrace();
+    for (StackTraceElement stackTraceElement : stackTrace) {
+      String trace = stackTraceElement.toString();
+      if (trace.startsWith(PACKAGE) && !(trace.contains(P6SPY_PACKAGE))) {
+        callStack.push(trace);
+      }
+    }
+
+    StringBuilder sb = new StringBuilder();
+    int order = 1;
+    while (!callStack.isEmpty()) {
+      sb.append("\n\t\t").append(order++).append(".").append(callStack.pop());
+    }
+
+    return sb.toString();
+  }
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/common/utils/logger/P6SpySqlFormatter.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/utils/logger/P6SpySqlFormatter.java
@@ -8,6 +8,9 @@ import java.util.ArrayDeque;
 import org.hibernate.engine.jdbc.internal.FormatStyle;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * p6spy 설정.
+ */
 @Configuration
 public class P6SpySqlFormatter implements MessageFormattingStrategy {
 
@@ -20,10 +23,12 @@ public class P6SpySqlFormatter implements MessageFormattingStrategy {
   }
 
   @Override
-  public String formatMessage(int connectionId, String now, long elapsed, String category, String prepared,
+  public String formatMessage(int connectionId, String now, long elapsed, String category,
+      String prepared,
       String sql, String url) {
     sql = formatSql(category, sql);
-    return String.format("[%s] | %d ms | %s | %s", category, elapsed, createStack(), formatSql(category, sql));
+    return String.format("[%s] | %d ms | %s | %s", category, elapsed, createStack(),
+        formatSql(category, sql));
   }
 
   private String formatSql(String category, String sql) {

--- a/pickly-service/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/pickly-service/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.github.gavlyukovskiy.boot.jdbc.decorator.DataSourceDecoratorAutoConfiguration

--- a/pickly-service/src/main/resources/application-local.yml
+++ b/pickly-service/src/main/resources/application-local.yml
@@ -9,8 +9,8 @@ spring:
     database: postgresql
     properties:
       hibernate:
-        format_sql: false
-        show_sql: false
+        format_sql: true
+        show_sql: true
   # schema.sql, data.sql 사용 여부
   sql:
     init:

--- a/pickly-service/src/main/resources/application-local.yml
+++ b/pickly-service/src/main/resources/application-local.yml
@@ -9,8 +9,8 @@ spring:
     database: postgresql
     properties:
       hibernate:
-        format_sql: true
-        show_sql: true
+        format_sql: false
+        show_sql: false
   # schema.sql, data.sql 사용 여부
   sql:
     init:
@@ -31,3 +31,9 @@ logging:
 pickly:
   enabled:
     access: true
+
+# p6spy
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true

--- a/pickly-service/src/main/resources/application-test.yml
+++ b/pickly-service/src/main/resources/application-test.yml
@@ -7,10 +7,6 @@ spring:
         enabled: always
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     database: postgresql
-    properties:
-      hibernate:
-        format_sql: false
-        show_sql: false
   # schema.sql, data.sql 사용 여부
   sql:
     init:

--- a/pickly-service/src/main/resources/application-test.yml
+++ b/pickly-service/src/main/resources/application-test.yml
@@ -9,8 +9,8 @@ spring:
     database: postgresql
     properties:
       hibernate:
-        format_sql: true
-        show_sql: true
+        format_sql: false
+        show_sql: false
   # schema.sql, data.sql 사용 여부
   sql:
     init:
@@ -31,3 +31,9 @@ logging:
 pickly:
   enabled:
     access: true
+
+# p6spy
+decorator:
+  datasource:
+    p6spy:
+      enable-logging: true

--- a/pickly-service/src/main/resources/application.yml
+++ b/pickly-service/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   # 실행할 프로필 정보
   profiles:
-    active: local
+    active: test
   # multipart 이용 시 파일/리퀘스트 사이즈 제한
   servlet:
     multipart:

--- a/pickly-service/src/main/resources/spy.properties
+++ b/pickly-service/src/main/resources/spy.properties
@@ -1,0 +1,1 @@
+appender=com.p6spy.engine.spy.appender.Slf4JLogger


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #29 
- hibernate에서 기본으로 제공해주는 쿼리 로그의 불편함을 개선하기 위해 p6spy 도입

<br>

## 🔨 작업 사항 (필수)

- p6spy 설정 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 일반 hibernate 로깅 + bind parameter를 적용한 화면입니다. (사진은 구글에서 퍼왔어용)
![image2018-8-22_9-55-31-1024x216](https://user-images.githubusercontent.com/38103085/225484725-946c2aaf-6fb7-4573-a5dc-68dd94675ae6.png)

- p6spy 로깅을 적용한 화면입니다. 어디서 / 어떤 경로로 / 어떤 parameter로 쿼리가 실행되었는지 로그가 기록됩니다. 
<img width="1025" alt="스크린샷 2023-03-16 오전 10 05 49" src="https://user-images.githubusercontent.com/38103085/225483384-3a7e75db-a16f-480b-ba3b-0a29e4b111bc.png">

내 코드에서 쿼리가 몇 번 호출되는지, 인자는 잘 들어갔는지, 1차 캐시나 더티체크가 잘 돌아가는지 등등을 로그로 쉽게 확인할 수 있습니다. 
stack trace를 이용해 쿼리 호출 위치로 바로 이동도 할 수 있구요 (저거 링크라서 누르면 파일로 자동 이동해요!)
우리 개발 좀 더 푸르게 푸르게 ^^7

<br>

## 🌱 연관 내용 (선택)

- stack trace를 사용하고, 동작하는 쿼리를 모두 로깅하기에 리소스를 꽤 잡아먹습니다. test, local 환경에서만 사용하고 dev, prod에선 사용을 지양해주세요!
- Spring Boot 3에서 p6spy가 동작하지 않는 버전 이슈가 있었습니다. 아래 레퍼런스 참고해서 해결했어요!
  - https://www.inflearn.com/questions/721332/spring-boot-3-0-0-%EC%97%90%EC%84%9C-p6spy-%EC%A0%81%EC%9A%A9%EC%9D%B4-%EC%95%88%EB%90%A9%EB%8B%88%EB%8B%A4
  - https://github.com/gavlyukovskiy/spring-boot-data-source-decorator/issues/77#issuecomment-1424859461
