### PR TITLE
유저 탈퇴 기능을 추가합니다.

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package org.pickly.service.member.controller;
 
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,12 +15,14 @@ import org.pickly.service.member.controller.response.MemberProfileRes;
 import org.pickly.service.member.controller.response.MyProfileRes;
 import org.pickly.service.member.service.interfaces.MemberService;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -74,4 +78,13 @@ public class MemberController {
     );
   }
 
+  @DeleteMapping("/me")
+  @ResponseStatus(NO_CONTENT)
+  @Operation(summary = "Delete member")
+  public void deleteMember(
+      @Parameter(name = "loginId", description = "로그인 유저 ID 값", example = "1", required = true)
+      @Positive(message = "유저 ID는 양수입니다.") @RequestParam final Long loginId
+  ) {
+    memberService.deleteMember(loginId);
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/repository/interfaces/MemberRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/repository/interfaces/MemberRepository.java
@@ -1,8 +1,13 @@
 package org.pickly.service.member.repository.interfaces;
 
+import java.util.Optional;
 import org.pickly.service.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
+
+  boolean existsByIdAndDeletedAtIsNull(Long id);
+
+  Optional<Member> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
@@ -30,7 +31,6 @@ public class MemberServiceImpl implements MemberService {
     }
   }
 
-  @Transactional
   public void updateMyProfile(Long memberId, MemberProfileUpdateDTO request) {
     Member member = findById(memberId);
 
@@ -66,7 +66,6 @@ public class MemberServiceImpl implements MemberService {
   }
 
   @Override
-  @Transactional
   public void deleteMember(Long memberId) {
     Member member = findById(memberId);
     member.delete();

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -25,7 +25,7 @@ public class MemberServiceImpl implements MemberService {
 
   @Override
   public void existsById(Long memberId) {
-    if (!memberRepository.existsById(memberId)) {
+    if (!memberRepository.existsByIdAndDeletedAtIsNull(memberId)) {
       throw new EntityNotFoundException("존재하지 않는 유저입니다.");
     }
   }
@@ -61,8 +61,14 @@ public class MemberServiceImpl implements MemberService {
 
   @Override
   public Member findById(Long id) {
-    return memberRepository.findById(id)
+    return memberRepository.findByIdAndDeletedAtIsNull(id)
         .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 member 입니다."));
   }
 
+  @Override
+  @Transactional
+  public void deleteMember(Long memberId) {
+    Member member = findById(memberId);
+    member.delete();
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
@@ -16,4 +16,6 @@ public interface MemberService {
   MyProfileDTO findMyProfile(Long memberId);
 
   MemberProfileDTO findProfileById(Long loginId, Long memberId);
+
+  void deleteMember(Long memberId);
 }

--- a/pickly-service/src/test/groovy/org/pickly/service/member/service/MemberServiceSpec.groovy
+++ b/pickly-service/src/test/groovy/org/pickly/service/member/service/MemberServiceSpec.groovy
@@ -102,4 +102,25 @@ class MemberServiceSpec extends Specification {
         found.nickname == "수정"
         found.profileEmoji == "👎"
     }
+
+    def "사용자 탈퇴"() {
+        given:
+        var member = memberRepository.save(Member.builder()
+                .email("test@pickly.com")
+                .username("test")
+                .password(new Password("test"))
+                .name("테스트")
+                .nickname("테스트")
+                .profileEmoji("👍")
+                .isHardMode(false)
+                .build())
+
+        when:
+        memberService.deleteMember(member.id)
+
+        then:
+        var found = memberRepository.findById(member.id).orElse(null)
+
+        found != null
+    }
 }

--- a/pickly-service/src/test/groovy/org/pickly/service/member/service/MemberServiceSpec.groovy
+++ b/pickly-service/src/test/groovy/org/pickly/service/member/service/MemberServiceSpec.groovy
@@ -7,8 +7,6 @@ import org.pickly.service.category.CategoryFactory
 import org.pickly.service.category.repository.interfaces.CategoryRepository
 import org.pickly.service.friend.service.interfaces.FriendService
 import org.pickly.service.member.MemberFactory
-import org.pickly.service.member.entity.Member
-import org.pickly.service.member.entity.Password
 import org.pickly.service.member.repository.interfaces.MemberRepository
 import org.pickly.service.member.service.dto.MemberProfileUpdateDTO
 import org.pickly.service.member.service.interfaces.MemberService
@@ -105,15 +103,7 @@ class MemberServiceSpec extends Specification {
 
     def "사용자 탈퇴"() {
         given:
-        var member = memberRepository.save(Member.builder()
-                .email("test@pickly.com")
-                .username("test")
-                .password(new Password("test"))
-                .name("테스트")
-                .nickname("테스트")
-                .profileEmoji("👍")
-                .isHardMode(false)
-                .build())
+        var member = memberRepository.save(memberFactory.testMember())
 
         when:
         memberService.deleteMember(member.id)


### PR DESCRIPTION
## 📌 개요 (필수)

유저 탈퇴 기능을 추가합니다.

Resolves #88.

<br>

## 🔨 작업 사항 (필수)

`DELETE /api/members/me` API를 추가합니다.

- soft delete로, 사용자 조회 간에 deleted_at 이 null 인 것만 조회합니다.

<br>

## ⚡️ 관심 리뷰 (선택)

X

<br>

## 🌱 연관 내용 (선택)

X