### PR TITLE
유저 정보 조회 API에 북마크수, 팔로우수, 팔로잉수를 추가합니다.

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/bookmark/repository/interfaces/BookmarkRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/repository/interfaces/BookmarkRepository.java
@@ -11,4 +11,5 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
   @Query("select b from Bookmark b join fetch b.member m where b.id = :id")
   Optional<Bookmark> findOneById(@Param("id") Long id);
 
+  Long countByMemberId(Long memberId);
 }

--- a/pickly-service/src/main/java/org/pickly/service/friend/repository/interfaces/FriendRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/friend/repository/interfaces/FriendRepository.java
@@ -17,4 +17,8 @@ public interface FriendRepository extends JpaRepository<Friend, Long> {
 
   Optional<Friend> findByFollowerIdAndFolloweeId(Long followerId, Long followeeId);
 
+  Long countByFollowerId(Long followerId);
+
+  Long countByFolloweeId(Long followeeId);
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
@@ -17,6 +17,9 @@ public class MemberMapper {
         .nickname(dto.getNickname())
         .profileEmoji(dto.getProfileEmoji())
         .isFollowing(dto.getIsFollowing())
+        .followersCount(dto.getFollowersCount())
+        .followeesCount(dto.getFolloweesCount())
+        .bookmarksCount(dto.getBookmarksCount())
         .build();
   }
 
@@ -26,13 +29,17 @@ public class MemberMapper {
     );
   }
 
-  public MemberProfileDTO toMemberProfileDTO(Member member, Boolean isFollowing) {
+  public MemberProfileDTO toMemberProfileDTO(Member member, Boolean isFollowing,
+      Long followersCount, Long followeesCount, Long bookmarksCount) {
     return MemberProfileDTO.builder()
         .id(member.getId())
         .name(member.getName())
         .nickname(member.getNickname())
         .profileEmoji(member.getProfileEmoji())
         .isFollowing(isFollowing)
+        .followersCount(followersCount)
+        .followeesCount(followeesCount)
+        .bookmarksCount(bookmarksCount)
         .build();
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
@@ -2,21 +2,22 @@ package org.pickly.service.member.common;
 
 import org.pickly.service.member.controller.request.MemberProfileUpdateReq;
 import org.pickly.service.member.controller.response.MemberProfileRes;
+import org.pickly.service.member.controller.response.MyProfileRes;
 import org.pickly.service.member.entity.Member;
 import org.pickly.service.member.service.dto.MemberProfileDTO;
 import org.pickly.service.member.service.dto.MemberProfileUpdateDTO;
+import org.pickly.service.member.service.dto.MyProfileDTO;
 import org.springframework.stereotype.Component;
 
 @Component
 public class MemberMapper {
 
-  public MemberProfileRes toResponse(MemberProfileDTO dto) {
-    return MemberProfileRes.builder()
+  public MyProfileRes toResponse(MyProfileDTO dto) {
+    return MyProfileRes.builder()
         .id(dto.getId())
         .name(dto.getName())
         .nickname(dto.getNickname())
         .profileEmoji(dto.getProfileEmoji())
-        .isFollowing(dto.getIsFollowing())
         .followersCount(dto.getFollowersCount())
         .followeesCount(dto.getFolloweesCount())
         .bookmarksCount(dto.getBookmarksCount())
@@ -29,17 +30,36 @@ public class MemberMapper {
     );
   }
 
-  public MemberProfileDTO toMemberProfileDTO(Member member, Boolean isFollowing,
-      Long followersCount, Long followeesCount, Long bookmarksCount) {
+  public MyProfileDTO toMyProfileDTO(Member member, Long followersCount, Long followeesCount,
+      Long bookmarksCount) {
+    return MyProfileDTO.builder()
+        .id(member.getId())
+        .name(member.getName())
+        .nickname(member.getNickname())
+        .profileEmoji(member.getProfileEmoji())
+        .followersCount(followersCount)
+        .followeesCount(followeesCount)
+        .bookmarksCount(bookmarksCount)
+        .build();
+  }
+
+  public MemberProfileRes toResponse(MemberProfileDTO dto) {
+    return MemberProfileRes.builder()
+        .id(dto.getId())
+        .name(dto.getName())
+        .nickname(dto.getNickname())
+        .profileEmoji(dto.getProfileEmoji())
+        .isFollowing(dto.getIsFollowing())
+        .build();
+  }
+
+  public MemberProfileDTO toMemberProfileDTO(Member member, boolean isFollowing) {
     return MemberProfileDTO.builder()
         .id(member.getId())
         .name(member.getName())
         .nickname(member.getNickname())
         .profileEmoji(member.getProfileEmoji())
         .isFollowing(isFollowing)
-        .followersCount(followersCount)
-        .followeesCount(followeesCount)
-        .bookmarksCount(bookmarksCount)
         .build();
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.pickly.service.member.common.MemberMapper;
 import org.pickly.service.member.controller.request.MemberProfileUpdateReq;
 import org.pickly.service.member.controller.response.MemberProfileRes;
+import org.pickly.service.member.controller.response.MyProfileRes;
 import org.pickly.service.member.service.interfaces.MemberService;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -46,6 +47,17 @@ public class MemberController {
     memberService.updateMyProfile(memberId, memberMapper.toDTO(request));
   }
 
+  @GetMapping("/me")
+  @Operation(summary = "Get member profile")
+  public MyProfileRes getMemberProfile(
+      @Parameter(name = "loginId", description = "로그인 유저 ID 값", example = "3", required = true)
+      @Positive(message = "유저 ID는 양수입니다.") @RequestParam final Long loginId
+  ) {
+    return memberMapper.toResponse(
+        memberService.findMyProfile(loginId)
+    );
+  }
+
   @GetMapping("/{memberId}")
   @Operation(summary = "Get member profile")
   public MemberProfileRes getMemberProfile(
@@ -58,7 +70,7 @@ public class MemberController {
       @Positive(message = "유저 ID는 양수입니다.") @RequestParam final Long loginId
   ) {
     return memberMapper.toResponse(
-        memberService.findProfileByMemberId(memberId, loginId)
+        memberService.findProfileById(loginId, memberId)
     );
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/response/MemberProfileRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/response/MemberProfileRes.java
@@ -26,4 +26,12 @@ public class MemberProfileRes {
   @Schema(description = "is login member's followee?", example = "true")
   private Boolean isFollowing;
 
+  @Schema(description = "number of followers", example = "10")
+  private Long followersCount;
+
+  @Schema(description = "number of followees", example = "10")
+  private Long followeesCount;
+
+  @Schema(description = "number of bookmarks", example = "10")
+  private Long bookmarksCount;
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/response/MyProfileRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/response/MyProfileRes.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 @Schema(description = "Member profile response")
-public class MemberProfileRes {
+public class MyProfileRes {
 
   @Schema(description = "member ID (PK)", example = "1")
   private Long id;
@@ -22,7 +22,12 @@ public class MemberProfileRes {
 
   @Schema(description = "member profile emoji", example = "👨🏻‍💻")
   private String profileEmoji;
+  @Schema(description = "number of followers", example = "10")
+  private Long followersCount;
 
-  @Schema(description = "is login member's followee?", example = "true")
-  private Boolean isFollowing;
+  @Schema(description = "number of followees", example = "10")
+  private Long followeesCount;
+
+  @Schema(description = "number of bookmarks", example = "10")
+  private Long bookmarksCount;
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/dto/MemberProfileDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/dto/MemberProfileDTO.java
@@ -14,5 +14,8 @@ public class MemberProfileDTO {
   private String nickname;
   private String profileEmoji;
   private Boolean isFollowing;
+  private Long followersCount;
+  private Long followeesCount;
+  private Long bookmarksCount;
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/dto/MyProfileDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/dto/MyProfileDTO.java
@@ -7,11 +7,14 @@ import lombok.Getter;
 @Getter
 @Builder
 @AllArgsConstructor
-public class MemberProfileDTO {
+public class MyProfileDTO {
 
   private Long id;
   private String name;
   private String nickname;
   private String profileEmoji;
-  private Boolean isFollowing;
+  private Long followersCount;
+  private Long followeesCount;
+  private Long bookmarksCount;
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -2,6 +2,7 @@ package org.pickly.service.member.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.pickly.common.error.exception.EntityNotFoundException;
+import org.pickly.service.bookmark.repository.interfaces.BookmarkRepository;
 import org.pickly.service.friend.repository.interfaces.FriendRepository;
 import org.pickly.service.member.common.MemberMapper;
 import org.pickly.service.member.entity.Member;
@@ -19,6 +20,7 @@ public class MemberServiceImpl implements MemberService {
   private final MemberRepository memberRepository;
   private final FriendRepository friendRepository;
   private final MemberMapper memberMapper;
+  private final BookmarkRepository bookmarkRepository;
 
   @Override
   public void existsById(Long memberId) {
@@ -43,7 +45,11 @@ public class MemberServiceImpl implements MemberService {
   public MemberProfileDTO findProfileByMemberId(final Long memberId, final Long loginId) {
     Member member = findById(memberId);
     Boolean isFollowing = friendRepository.existsByFollowerIdAndFolloweeId(loginId, memberId);
-    return memberMapper.toMemberProfileDTO(member, isFollowing);
+    Long followersCount = friendRepository.countByFolloweeId(memberId);
+    Long followeesCount = friendRepository.countByFollowerId(memberId);
+    Long bookmarksCount = bookmarkRepository.countByMemberId(memberId);
+    return memberMapper.toMemberProfileDTO(member, isFollowing, followersCount, followeesCount,
+        bookmarksCount);
   }
 
   @Override

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -8,6 +8,7 @@ import org.pickly.service.member.common.MemberMapper;
 import org.pickly.service.member.entity.Member;
 import org.pickly.service.member.repository.interfaces.MemberRepository;
 import org.pickly.service.member.service.dto.MemberProfileDTO;
+import org.pickly.service.member.service.dto.MyProfileDTO;
 import org.pickly.service.member.service.dto.MemberProfileUpdateDTO;
 import org.pickly.service.member.service.interfaces.MemberService;
 import org.springframework.stereotype.Service;
@@ -42,14 +43,20 @@ public class MemberServiceImpl implements MemberService {
 
   @Override
   @Transactional(readOnly = true)
-  public MemberProfileDTO findProfileByMemberId(final Long memberId, final Long loginId) {
+  public MyProfileDTO findMyProfile(final Long memberId) {
     Member member = findById(memberId);
-    Boolean isFollowing = friendRepository.existsByFollowerIdAndFolloweeId(loginId, memberId);
     Long followersCount = friendRepository.countByFolloweeId(memberId);
     Long followeesCount = friendRepository.countByFollowerId(memberId);
     Long bookmarksCount = bookmarkRepository.countByMemberId(memberId);
-    return memberMapper.toMemberProfileDTO(member, isFollowing, followersCount, followeesCount,
-        bookmarksCount);
+    return memberMapper.toMyProfileDTO(member, followersCount, followeesCount, bookmarksCount);
+  }
+
+  @Override
+  @Transactional(readOnly = true)
+  public MemberProfileDTO findProfileById(final Long loginId, final Long memberId) {
+    boolean isFollowing = friendRepository.existsByFollowerIdAndFolloweeId(loginId, memberId);
+    Member member = findById(memberId);
+    return memberMapper.toMemberProfileDTO(member, isFollowing);
   }
 
   @Override

--- a/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
@@ -3,6 +3,7 @@ package org.pickly.service.member.service.interfaces;
 import org.pickly.service.member.entity.Member;
 import org.pickly.service.member.service.dto.MemberProfileDTO;
 import org.pickly.service.member.service.dto.MemberProfileUpdateDTO;
+import org.pickly.service.member.service.dto.MyProfileDTO;
 
 public interface MemberService {
 
@@ -12,6 +13,7 @@ public interface MemberService {
 
   Member findById(Long id);
 
-  MemberProfileDTO findProfileByMemberId(Long memberId, Long loginId);
+  MyProfileDTO findMyProfile(Long memberId);
 
+  MemberProfileDTO findProfileById(Long loginId, Long memberId);
 }

--- a/pickly-service/src/test/groovy/org/pickly/service/bookmark/BookmarkFactory.java
+++ b/pickly-service/src/test/groovy/org/pickly/service/bookmark/BookmarkFactory.java
@@ -5,48 +5,45 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.pickly.service.bookmark.entity.Bookmark;
 import org.pickly.service.bookmark.entity.Visibility;
-import org.pickly.service.category.CategoryFactory;
 import org.pickly.service.category.entity.Category;
-import org.pickly.service.member.MemberFactory;
 import org.pickly.service.member.entity.Member;
 
 public class BookmarkFactory {
 
-  private final MemberFactory memberFactory = new MemberFactory();
-
-  private final CategoryFactory categoryFactory = new CategoryFactory();
-
-  public Bookmark testBookmark() {
-    Member member = memberFactory.testMember();
+  public Bookmark testBookmark(Member member, Category category) {
     return Bookmark.builder()
-        .category(categoryFactory.testCategory(member))
+        .member(member)
+        .category(category)
         .title("검은 그림자 내 안에 깨어나")
         .url("https://pickly.com")
         .isUserLike(true)
         .visibility(Visibility.SCOPE_PUBLIC)
+        .readByUser(false)
         .build();
   }
 
-  public Bookmark testBookmark(int number) {
-    Member member = memberFactory.testMember();
+  public Bookmark testBookmark(int number, Member member, Category category) {
     return Bookmark.builder()
-        .category(categoryFactory.testCategory(member))
+        .member(member)
+        .category(category)
         .title("검은 그림자 내 안에 깨어나")
         .url("https://pickly.com/" + number)
         .isUserLike(true)
         .visibility(Visibility.SCOPE_PUBLIC)
+        .readByUser(false)
         .build();
   }
 
-  public List<Bookmark> testBookmarks(int amount) {
-    Member member = memberFactory.testMember();
+  public List<Bookmark> testBookmarks(int amount, Member member, Category category) {
     return IntStream.rangeClosed(1, amount)
         .mapToObj(i -> Bookmark.builder()
-            .category(categoryFactory.testCategory(member))
+            .member(member)
+            .category(category)
             .title("검은 그림자 내 안에 깨어나")
             .url("https://pickly.com/" + i)
             .isUserLike(true)
             .visibility(Visibility.SCOPE_PUBLIC)
+            .readByUser(false)
             .build())
         .collect(Collectors.toList());
   }

--- a/pickly-service/src/test/groovy/org/pickly/service/bookmark/services/BookmarkServiceSpec.groovy
+++ b/pickly-service/src/test/groovy/org/pickly/service/bookmark/services/BookmarkServiceSpec.groovy
@@ -2,10 +2,11 @@ package org.pickly.service.bookmark.services
 
 import org.pickly.service.bookmark.BookmarkFactory
 import org.pickly.service.bookmark.entity.Bookmark
-import org.pickly.service.member.MemberFactory
 import org.pickly.service.bookmark.repository.interfaces.BookmarkRepository
 import org.pickly.service.bookmark.service.interfaces.BookmarkService
-import org.pickly.service.member.entity.Member
+import org.pickly.service.category.CategoryFactory
+import org.pickly.service.category.repository.interfaces.CategoryRepository
+import org.pickly.service.member.MemberFactory
 import org.pickly.service.member.repository.interfaces.MemberRepository
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
@@ -19,26 +20,36 @@ import spock.lang.Specification
 class BookmarkServiceSpec extends Specification {
 
     @Autowired
-    private BookmarkService bookmarkService;
+    private BookmarkService bookmarkService
 
     @Autowired
     private BookmarkRepository bookmarkRepository;
 
+    @Autowired
+    private CategoryRepository categoryRepository
+
+    @Autowired
+    private MemberRepository memberRepository;
+
     private BookmarkFactory bookmarkFactory = new BookmarkFactory();
+    private CategoryFactory categoryFactory = new CategoryFactory();
+    private MemberFactory memberFactory = new MemberFactory();
 
     def "유저가 좋아하는 북마크 수 조회"() {
         given:
-        List<Bookmark> bookmarkList = bookmarkFactory.testBookmarks(3);
+        var member = memberFactory.testMember()
+        memberRepository.save(member)
+        var category = categoryFactory.testCategory(member)
+        categoryRepository.save(category)
+        List<Bookmark> bookmarkList = bookmarkFactory.testBookmarks(3, member, category);
         bookmarkList.each { entity ->
             bookmarkRepository.save(entity)
         }
 
         when:
-        def count = bookmarkService.countMemberLikes(member)
+        def count = bookmarkService.countMemberLikes(bookmarkList[0].member.id)
 
         then:
         count == 3
     }
-
-
 }

--- a/pickly-service/src/test/groovy/org/pickly/service/bookmark/services/BookmarkServiceSpec.groovy
+++ b/pickly-service/src/test/groovy/org/pickly/service/bookmark/services/BookmarkServiceSpec.groovy
@@ -47,7 +47,7 @@ class BookmarkServiceSpec extends Specification {
         }
 
         when:
-        def count = bookmarkService.countMemberLikes(bookmarkList[0].member.id)
+        def count = bookmarkService.countMemberLikes(member.id)
 
         then:
         count == 3

--- a/pickly-service/src/test/groovy/org/pickly/service/bookmark/services/BookmarkServiceSpec.groovy
+++ b/pickly-service/src/test/groovy/org/pickly/service/bookmark/services/BookmarkServiceSpec.groovy
@@ -23,17 +23,17 @@ class BookmarkServiceSpec extends Specification {
     private BookmarkService bookmarkService
 
     @Autowired
-    private BookmarkRepository bookmarkRepository;
+    private BookmarkRepository bookmarkRepository
 
     @Autowired
     private CategoryRepository categoryRepository
 
     @Autowired
-    private MemberRepository memberRepository;
+    private MemberRepository memberRepository
 
-    private BookmarkFactory bookmarkFactory = new BookmarkFactory();
-    private CategoryFactory categoryFactory = new CategoryFactory();
-    private MemberFactory memberFactory = new MemberFactory();
+    private BookmarkFactory bookmarkFactory = new BookmarkFactory()
+    private CategoryFactory categoryFactory = new CategoryFactory()
+    private MemberFactory memberFactory = new MemberFactory()
 
     def "유저가 좋아하는 북마크 수 조회"() {
         given:
@@ -41,7 +41,7 @@ class BookmarkServiceSpec extends Specification {
         memberRepository.save(member)
         var category = categoryFactory.testCategory(member)
         categoryRepository.save(category)
-        List<Bookmark> bookmarkList = bookmarkFactory.testBookmarks(3, member, category);
+        List<Bookmark> bookmarkList = bookmarkFactory.testBookmarks(3, member, category)
         bookmarkList.each { entity ->
             bookmarkRepository.save(entity)
         }

--- a/pickly-service/src/test/groovy/org/pickly/service/category/CategoryFactory.java
+++ b/pickly-service/src/test/groovy/org/pickly/service/category/CategoryFactory.java
@@ -11,13 +11,6 @@ public class CategoryFactory {
 
   private final MemberFactory memberFactory = new MemberFactory();
 
-  public Category testCategory() {
-    return Category.builder()
-        .member(memberFactory.testMember())
-        .isAutoDeleteMode(false)
-        .name("당장 내일 안으로 읽어야 하는 자바 면접 질문")
-        .build();
-  }
 
   public Category testCategory(Member member) {
     return Category.builder()

--- a/pickly-service/src/test/groovy/org/pickly/service/friend/service/FriendServiceSpec.groovy
+++ b/pickly-service/src/test/groovy/org/pickly/service/friend/service/FriendServiceSpec.groovy
@@ -45,7 +45,7 @@ class FriendServiceSpec extends Specification {
                 .nickname("프론트엔드")
                 .profileEmoji("👍")
                 .isHardMode(false)
-                .build());
+                .build())
 
         var followee = memberRepository.save(Member.builder()
                 .email("backend@pickly.com")
@@ -55,7 +55,7 @@ class FriendServiceSpec extends Specification {
                 .nickname("백엔드")
                 .profileEmoji("👍")
                 .isHardMode(false)
-                .build());
+                .build())
 
         friendService.follow(follower.id, followee.id)
         var REQUEST = new FriendNotificationStatusReqDTO(followee.id, true)
@@ -65,7 +65,7 @@ class FriendServiceSpec extends Specification {
 
         then:
         def friend = friendRepository.findByFollowerIdAndFolloweeId(follower.getId(), followee.getId()).orElseThrow(
-                () -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
+                () -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE))
         friend.notificationEnabled == true
     }
 
@@ -80,7 +80,7 @@ class FriendServiceSpec extends Specification {
                 .nickname("프론트엔드")
                 .profileEmoji("👍")
                 .isHardMode(false)
-                .build());
+                .build())
 
         var followee = memberRepository.save(Member.builder()
                 .email("backend@pickly.com")
@@ -90,7 +90,7 @@ class FriendServiceSpec extends Specification {
                 .nickname("백엔드")
                 .profileEmoji("👍")
                 .isHardMode(false)
-                .build());
+                .build())
 
         friendService.follow(follower.id, followee.id)
         var REQUEST = new FriendNotificationStatusReqDTO(followee.id, false)
@@ -101,7 +101,7 @@ class FriendServiceSpec extends Specification {
 
         then:
         def friend = friendRepository.findByFollowerIdAndFolloweeId(follower.getId(), followee.getId()).orElseThrow(
-                () -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE));
+                () -> new BusinessException(ErrorCode.INVALID_INPUT_VALUE))
         friend.notificationEnabled == false
     }
 
@@ -115,7 +115,7 @@ class FriendServiceSpec extends Specification {
                 .nickname("프론트엔드")
                 .profileEmoji("👍")
                 .isHardMode(false)
-                .build());
+                .build())
 
         var followee = memberRepository.save(Member.builder()
                 .email("backend@pickly.com")
@@ -125,7 +125,7 @@ class FriendServiceSpec extends Specification {
                 .nickname("백엔드")
                 .profileEmoji("👍")
                 .isHardMode(false)
-                .build());
+                .build())
 
         var REQUEST = new FriendNotificationStatusReqDTO(followee.id, true)
 

--- a/pickly-service/src/test/groovy/org/pickly/service/member/MemberFactory.java
+++ b/pickly-service/src/test/groovy/org/pickly/service/member/MemberFactory.java
@@ -5,15 +5,21 @@ import org.pickly.service.member.entity.Password;
 
 public class MemberFactory {
 
-  public Member testMember() {
+  public Member testMember(String username, String email, String name, String nickname,
+      String profileEmoji) {
     return Member.builder()
-        .username("picko123")
+        .username(username)
         .password(new Password("nobodyKnows123"))
         .isHardMode(false)
-        .email("picko123@gmail.com")
-        .name("picko")
-        .nickname("iAmNotAPickyEater")
+        .email(email)
+        .name(name)
+        .nickname(nickname)
+        .profileEmoji(profileEmoji)
         .build();
   }
 
+  public Member testMember() {
+    return testMember("picko123", "picko123@gmail.com", "picko",
+        "iAmNotAPickyEater", "👍");
+  }
 }

--- a/pickly-service/src/test/groovy/org/pickly/service/member/service/MemberServiceSpec.groovy
+++ b/pickly-service/src/test/groovy/org/pickly/service/member/service/MemberServiceSpec.groovy
@@ -5,8 +5,8 @@ import org.pickly.service.bookmark.BookmarkFactory
 import org.pickly.service.bookmark.repository.interfaces.BookmarkRepository
 import org.pickly.service.category.CategoryFactory
 import org.pickly.service.category.repository.interfaces.CategoryRepository
-import org.pickly.service.friend.repository.interfaces.FriendRepository
 import org.pickly.service.friend.service.interfaces.FriendService
+import org.pickly.service.member.MemberFactory
 import org.pickly.service.member.entity.Member
 import org.pickly.service.member.entity.Password
 import org.pickly.service.member.repository.interfaces.MemberRepository
@@ -36,6 +36,7 @@ class MemberServiceSpec extends Specification {
     @Autowired
     private FriendService friendService
 
+    private memberFactory = new MemberFactory()
     private bookmarkFactory = new BookmarkFactory()
     private categoryFactory = new CategoryFactory()
 
@@ -44,59 +45,51 @@ class MemberServiceSpec extends Specification {
         memberRepository.deleteAll()
     }
 
-    def "사용자 프로필 조회"() {
+    def "내 프로필 조회"() {
         given:
-        var member = memberRepository.save(Member.builder()
-                .email("test@pickly.com")
-                .username("test")
-                .password(new Password("test"))
-                .name("테스트")
-                .nickname("테스트")
-                .profileEmoji("👍")
-                .isHardMode(false)
-                .build())
+        var member = memberRepository.save(memberFactory.testMember())
 
         var category = categoryRepository.save(categoryFactory.testCategory(member))
         bookmarkRepository.save(bookmarkFactory.testBookmark(member, category))
 
-        var member2 = memberRepository.save(Member.builder()
-                .email("test2@pickly.com")
-                .username("test2")
-                .password(new Password("test"))
-                .name("테스트2")
-                .nickname("테스트2")
-                .profileEmoji("👍")
-                .isHardMode(false)
-                .build())
+        var member2 = memberRepository.save(memberFactory.testMember("picko2",
+                "picko2@pickly.com", "picko2", "picko2", "👎"))
 
         friendService.follow(member.id, member2.id)
         friendService.follow(member2.id, member.id)
 
         when:
-        def dto = memberService.findProfileByMemberId(member.id, member.id)
+        def dto = memberService.findMyProfile(member.id)
 
         then:
         dto != null
-        dto.name == "테스트"
-        dto.nickname == "테스트"
+        dto.name == "picko"
+        dto.nickname == "iAmNotAPickyEater"
         dto.profileEmoji == "👍"
         dto.bookmarksCount == 1
         dto.followersCount == 1
         dto.followeesCount == 1
     }
 
+    def "사용자 프로필 조회"() {
+        given:
+        var member = memberRepository.save(memberFactory.testMember())
+
+        when:
+        def dto = memberService.findProfileById(member.id, member.id)
+
+        then:
+        dto != null
+        dto.name == "picko"
+        dto.nickname == "iAmNotAPickyEater"
+        dto.profileEmoji == "👍"
+        dto.isFollowing == false
+    }
+
 
     def "사용자 프로필 수정"() {
         given:
-        var member = memberRepository.save(Member.builder()
-                .email("test@pickly.com")
-                .username("test")
-                .password(new Password("test"))
-                .name("테스트")
-                .nickname("테스트")
-                .profileEmoji("👍")
-                .isHardMode(false)
-                .build())
+        var member = memberRepository.save(memberFactory.testMember())
 
         when:
         memberService.updateMyProfile(member.id, new MemberProfileUpdateDTO("수정", "수정", "👎"))


### PR DESCRIPTION
## 📌 개요 (필수)


유저 정보 조회 API에 북마크수, 팔로우수, 팔로잉수를 조회할 수 있는 기능을 추가합니다.

Resolves #87.

<br>

## 🔨 작업 사항 (필수)

유저 정보 조회 API에 북마크수, 팔로우수, 팔로잉수를 조회할 수 있는 기능을 추가합니다.

기존 API와 동일하게 접근하면 되며, 다음 payload를 반환합니다.

`GET /api/members/:memberId?loginId=1`

```json
{
    "id": 1,
    "name": "테스트1",
    "nickname": "테스트1",
    "profileEmoji": "😎",
    "isFollowing": false,
    "followersCount": 1,
    "followeesCount": 1,
    "bookmarksCount": 6
}
```

<br>

## ⚡️ 관심 리뷰 (선택)

X

<br>

## 🌱 연관 내용 (선택)

테스트 수정이 들어간 #82 가 먼저 머지되면 이상적이겠으나, 이게 먼저 머지되어도 괜찮을 것 같습니다.