### PR TITLE
[feat] 알림 기준 설정 API를 추가합니다.

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
@@ -37,7 +37,7 @@ public class MemberMapper {
   }
 
   public MemberModeRes toResponse(MemberModeDTO dto) {
-    return new MemberModeRes(dto.getIsHardMode(), dto.getStandardDate());
+    return new MemberModeRes(dto.getIsHardMode(), dto.getNotifyDailyAt());
   }
 
   public MemberProfileUpdateDTO toDTO(MemberProfileUpdateReq request) {
@@ -90,7 +90,7 @@ public class MemberMapper {
   public MemberModeDTO toMemberModeDTO(Member member, NotificationStandard standard) {
     return MemberModeDTO.builder()
         .isHardMode(member.getIsHardMode())
-        .standardDate(standard.getStandardDate())
+        .notifyDailyAt(standard.getNotifyDailyAt())
         .build();
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/response/MemberModeRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/response/MemberModeRes.java
@@ -1,6 +1,7 @@
 package org.pickly.service.member.controller.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,8 +15,8 @@ public class MemberModeRes {
   @Schema(description = "하드 모드 사용 유저인가?", example = "true")
   private boolean isHardMode;
 
-  @Schema(description = "알림 기준 일자. 00일 안에 읽지 않으면 알림 발생", example = "3")
-  private int standardDate;
+  @Schema(description = "알림 기준 일자. 00일 안에 읽지 않으면 알림 발생", example = "09:00")
+  private LocalTime notifyDailyAt;
 
   public boolean getIsHardMode() {
     return this.isHardMode;

--- a/pickly-service/src/main/java/org/pickly/service/member/service/dto/MemberModeDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/dto/MemberModeDTO.java
@@ -1,5 +1,6 @@
 package org.pickly.service.member.service.dto;
 
+import java.time.LocalTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +11,6 @@ import lombok.Getter;
 public class MemberModeDTO {
 
   private Boolean isHardMode;
-  private Integer standardDate;
+  private LocalTime notifyDailyAt;
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -15,7 +15,7 @@ import org.pickly.service.member.service.dto.MemberStatusDTO;
 import org.pickly.service.member.service.dto.MyProfileDTO;
 import org.pickly.service.member.service.interfaces.MemberService;
 import org.pickly.service.notification.entity.NotificationStandard;
-import org.pickly.service.notification.service.interfaces.NotificationStandardService;
+import org.pickly.service.notification.repository.interfaces.NotificationStandardRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,11 +24,17 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberServiceImpl implements MemberService {
 
-  private final NotificationStandardService notificationStandardService;
   private final MemberRepository memberRepository;
   private final FriendRepository friendRepository;
   private final MemberMapper memberMapper;
   private final BookmarkRepository bookmarkRepository;
+  private final NotificationStandardRepository notificationStandardRepository;
+
+  @Transactional(readOnly = true)
+  public NotificationStandard findNotificationStandardByMemberId(final Long memberId) {
+    return notificationStandardRepository.findByMemberId(memberId)
+        .orElseThrow(() -> new EntityNotFoundException("요청 member의 알림 기준이 존재하지 않습니다."));
+  }
 
   @Override
   public void existsById(Long memberId) {
@@ -76,7 +82,7 @@ public class MemberServiceImpl implements MemberService {
 
   public MemberModeDTO findModeByMemberId(final Long memberId) {
     Member member = findById(memberId);
-    NotificationStandard standard = notificationStandardService.findByMember(memberId);
+    NotificationStandard standard = findNotificationStandardByMemberId(memberId);
     return memberMapper.toMemberModeDTO(member, standard);
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/notification/controller/NotificationStandardController.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/controller/NotificationStandardController.java
@@ -1,0 +1,76 @@
+package org.pickly.service.notification.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.pickly.service.notification.controller.request.NotificationStandardCreateReq;
+import org.pickly.service.notification.controller.response.NotificationStandardRes;
+import org.pickly.service.notification.mapper.NotificationStandardMapper;
+import org.pickly.service.notification.service.interfaces.NotificationStandardService;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/notification-standards")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "NotificationStandard", description = "알림 기준 설정 API")
+public class NotificationStandardController {
+
+  private final NotificationStandardService notificationStandardService;
+  private final NotificationStandardMapper notificationStandardMapper;
+
+  @GetMapping("/me")
+  @Operation(summary = "내 알림 기준 조회")
+  public NotificationStandardRes findMyNotificationStandard(
+      @RequestParam
+      @Parameter(name = "loginId", description = "로그인 유저 ID 값", example = "3", required = true)
+      @Positive(message = "유저 ID는 양수입니다.") final Long loginId
+  ) {
+    return notificationStandardMapper.toResponse(
+        notificationStandardService.findByMemberId(loginId));
+  }
+
+  @PostMapping
+  @Operation(summary = "알림 기준 생성")
+  public void createMyNotificationStandard(
+      @RequestParam
+      @Parameter(name = "loginId", description = "로그인 유저 ID 값", example = "3", required = true)
+      @Positive(message = "유저 ID는 양수입니다.") final Long loginId,
+
+      @RequestBody
+      @Valid
+      NotificationStandardCreateReq request
+  ) {
+    notificationStandardService.createNotificationStandard(
+        loginId,
+        notificationStandardMapper.toCreateDTO(request)
+    );
+  }
+
+  @PutMapping("/me")
+  @Operation(summary = "내 알림 기준 수정")
+  public void updateMyNotificationStandard(
+      @RequestParam
+      @Parameter(name = "loginId", description = "로그인 유저 ID 값", example = "3", required = true)
+      @Positive(message = "유저 ID는 양수입니다.") final Long loginId,
+
+      @RequestBody
+      @Valid
+      NotificationStandardCreateReq request
+  ) {
+    notificationStandardService.updateNotificationStandard(
+        loginId,
+        notificationStandardMapper.toUpdateDTO(request)
+    );
+  }
+}

--- a/pickly-service/src/main/java/org/pickly/service/notification/controller/request/NotificationStandardCreateReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/controller/request/NotificationStandardCreateReq.java
@@ -1,0 +1,21 @@
+package org.pickly.service.notification.controller.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "Notification standard create request")
+public class NotificationStandardCreateReq {
+
+  @Schema(description = "Is notification activated", example = "true")
+  @NotNull(message = "알림 활성화 여부를 입력해주세요.")
+  private Boolean isActive;
+
+  @Schema(description = "notify daily at", example = "09:00")
+  @NotNull(message = "매일 알림 받을 시간을 입력해주세요.")
+  private LocalTime notifyDailyAt;
+}

--- a/pickly-service/src/main/java/org/pickly/service/notification/controller/request/NotificationStandardUpdateReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/controller/request/NotificationStandardUpdateReq.java
@@ -1,0 +1,21 @@
+package org.pickly.service.notification.controller.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "Notification standard update request")
+public class NotificationStandardUpdateReq {
+
+  @Schema(description = "Is notification activated", example = "true")
+  @NotNull(message = "알림 활성화 여부를 입력해주세요.")
+  private Boolean isActive;
+
+  @Schema(description = "notify daily at", example = "09:00")
+  @NotNull(message = "매일 알림 받을 시간을 입력해주세요.")
+  private LocalTime notifyDailyAt;
+}

--- a/pickly-service/src/main/java/org/pickly/service/notification/controller/response/NotificationStandardRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/controller/response/NotificationStandardRes.java
@@ -1,0 +1,18 @@
+package org.pickly.service.notification.controller.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Schema(description = "Notification standard response")
+public class NotificationStandardRes {
+
+  @Schema(description = "is active?", example = "true")
+  private Boolean isActive;
+
+  @Schema(description = "notify daily at", example = "09:00")
+  private LocalTime notifyDailyAt;
+}

--- a/pickly-service/src/main/java/org/pickly/service/notification/entity/NotificationStandard.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/entity/NotificationStandard.java
@@ -6,10 +6,11 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalTime;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import org.pickly.service.common.utils.base.BaseEntity;
@@ -20,18 +21,22 @@ import org.pickly.service.member.entity.Member;
 @DynamicInsert
 @DynamicUpdate
 @Table(name = "notification_standard")
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class NotificationStandard extends BaseEntity {
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "member_id")
+  @JoinColumn(name = "member_id", nullable = false, unique = true)
   private Member member;
 
   @Column(name = "is_active", nullable = false)
   private Boolean isActive;
 
-  @ColumnDefault("7")
-  @Column(name = "standard_date", nullable = false)
-  private Integer standardDate;
+  @Column(name = "notify_daily_at", nullable = false)
+  private LocalTime notifyDailyAt;
 
+  public void update(Boolean isActive, LocalTime notifyDailyAt) {
+    this.isActive = isActive;
+    this.notifyDailyAt = notifyDailyAt;
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/notification/mapper/NotificationStandardMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/mapper/NotificationStandardMapper.java
@@ -1,0 +1,32 @@
+package org.pickly.service.notification.mapper;
+
+import org.pickly.service.notification.controller.request.NotificationStandardCreateReq;
+import org.pickly.service.notification.controller.response.NotificationStandardRes;
+import org.pickly.service.notification.entity.NotificationStandard;
+import org.pickly.service.notification.service.dto.NotificationStandardDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationStandardMapper {
+
+  public NotificationStandardDTO toCreateDTO(NotificationStandardCreateReq request) {
+    return new NotificationStandardDTO(
+        request.getIsActive(),
+        request.getNotifyDailyAt()
+    );
+  }
+
+  public NotificationStandardDTO toUpdateDTO(NotificationStandardCreateReq request) {
+    return new NotificationStandardDTO(
+        request.getIsActive(),
+        request.getNotifyDailyAt()
+    );
+  }
+
+  public NotificationStandardRes toResponse(NotificationStandard dto) {
+    return new NotificationStandardRes(
+        dto.getIsActive(),
+        dto.getNotifyDailyAt()
+    );
+  }
+}

--- a/pickly-service/src/main/java/org/pickly/service/notification/repository/interfaces/NotificationStandardRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/repository/interfaces/NotificationStandardRepository.java
@@ -8,4 +8,5 @@ public interface NotificationStandardRepository extends JpaRepository<Notificati
 
   Optional<NotificationStandard> findByMemberId(Long memberId);
 
+  boolean existsByMemberId(Long memberId);
 }

--- a/pickly-service/src/main/java/org/pickly/service/notification/service/dto/NotificationStandardDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/service/dto/NotificationStandardDTO.java
@@ -1,0 +1,14 @@
+package org.pickly.service.notification.service.dto;
+
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationStandardDTO {
+
+  private boolean isActive;
+
+  private LocalTime notifyDailyAt;
+}

--- a/pickly-service/src/main/java/org/pickly/service/notification/service/impl/NotificationStandardServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/service/impl/NotificationStandardServiceImpl.java
@@ -1,23 +1,50 @@
 package org.pickly.service.notification.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.pickly.common.error.exception.BusinessException;
 import org.pickly.common.error.exception.EntityNotFoundException;
+import org.pickly.common.error.exception.ErrorCode;
+import org.pickly.service.member.common.MemberMapper;
+import org.pickly.service.member.service.interfaces.MemberService;
 import org.pickly.service.notification.entity.NotificationStandard;
+import org.pickly.service.notification.mapper.NotificationStandardMapper;
 import org.pickly.service.notification.repository.interfaces.NotificationStandardRepository;
+import org.pickly.service.notification.service.dto.NotificationStandardDTO;
 import org.pickly.service.notification.service.interfaces.NotificationStandardService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class NotificationStandardServiceImpl implements NotificationStandardService {
 
   private final NotificationStandardRepository notificationStandardRepository;
+  private final MemberService memberService;
 
   @Override
-  public NotificationStandard findByMember(final Long memberId) {
-    return notificationStandardRepository.findByMemberId(memberId).orElseThrow(
-        () -> new EntityNotFoundException("요청 member의 알림 기준이 존재하지 않습니다.")
+  @Transactional(readOnly = true)
+  public NotificationStandard findByMemberId(final Long memberId) {
+    return notificationStandardRepository.findByMemberId(memberId)
+        .orElseThrow(() -> new EntityNotFoundException("요청 member의 알림 기준 설정이 존재하지 않습니다."));
+  }
+
+  @Override
+  public void createNotificationStandard(Long memberId, NotificationStandardDTO dto) {
+    if (notificationStandardRepository.existsByMemberId(memberId)) {
+      throw new BusinessException("이미 알림 기준 설정이 존재합니다.", ErrorCode.ENTITY_CONFLICT);
+    }
+
+    notificationStandardRepository.save(
+        new NotificationStandard(
+            memberService.findById(memberId), dto.isActive(), dto.getNotifyDailyAt()
+        )
     );
   }
 
+  @Override
+  public void updateNotificationStandard(Long memberId, NotificationStandardDTO dto) {
+    NotificationStandard notificationStandard = findByMemberId(memberId);
+    notificationStandard.update(dto.isActive(), dto.getNotifyDailyAt());
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/notification/service/interfaces/NotificationStandardService.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/service/interfaces/NotificationStandardService.java
@@ -1,9 +1,13 @@
 package org.pickly.service.notification.service.interfaces;
 
 import org.pickly.service.notification.entity.NotificationStandard;
+import org.pickly.service.notification.service.dto.NotificationStandardDTO;
 
 public interface NotificationStandardService {
 
-  NotificationStandard findByMember(Long memberId);
+  NotificationStandard findByMemberId(Long memberId);
 
+  void createNotificationStandard(Long memberId, NotificationStandardDTO dto);
+
+  void updateNotificationStandard(Long memberId, NotificationStandardDTO dto);
 }

--- a/pickly-service/src/main/resources/data.sql
+++ b/pickly-service/src/main/resources/data.sql
@@ -27,10 +27,11 @@ INSERT INTO friend
 VALUES (1, 2, false),
        (2, 1, true);
 
+-- notify_daily_at is  time without timezone
 INSERT INTO notification_standard
-    (member_id, standard_date, is_active)
-VALUES (1, 7, true),
-       (2, 3, false);
+    (member_id, notify_daily_at, is_active)
+VALUES (1, '09:00:00', true),
+       (2, '18:00:00', false);
 
 INSERT INTO notification
     (member_id, bookmark_id, title, content, is_checked, notification_type)

--- a/pickly-service/src/main/resources/schema.sql
+++ b/pickly-service/src/main/resources/schema.sql
@@ -163,7 +163,7 @@ create table notification_standard
         constraint bookmark_member_id_fk
         references member
         on update cascade on delete cascade,
-    standard_date integer   default 7     not null,
+    notify_daily_at time                  not null,
     is_active     boolean                 not null,
     created_at    timestamp default now() not null,
     updated_at    timestamp,

--- a/pickly-service/src/test/groovy/org/pickly/service/notification/NotificationStandardFactory.java
+++ b/pickly-service/src/test/groovy/org/pickly/service/notification/NotificationStandardFactory.java
@@ -1,0 +1,18 @@
+package org.pickly.service.notification;
+
+import java.time.LocalTime;
+import org.pickly.service.member.entity.Member;
+import org.pickly.service.notification.entity.NotificationStandard;
+
+public class NotificationStandardFactory {
+
+  public NotificationStandard testNotificationStandard(Member member) {
+    return testNotificationStandard(member, true, LocalTime.of(9, 0));
+  }
+
+  public NotificationStandard testNotificationStandard(
+      Member member, Boolean isActive, LocalTime notifyDailyAt
+  ) {
+    return new NotificationStandard(member, isActive, notifyDailyAt);
+  }
+}

--- a/pickly-service/src/test/groovy/org/pickly/service/notification/service/NotificationStandardServiceSpec.groovy
+++ b/pickly-service/src/test/groovy/org/pickly/service/notification/service/NotificationStandardServiceSpec.groovy
@@ -1,0 +1,110 @@
+package org.pickly.service.notification.service
+
+import org.junit.jupiter.api.BeforeEach
+import org.pickly.common.error.exception.BusinessException
+import org.pickly.service.member.MemberFactory
+import org.pickly.service.member.repository.interfaces.MemberRepository
+import org.pickly.service.notification.NotificationStandardFactory
+import org.pickly.service.notification.repository.interfaces.NotificationStandardRepository
+import org.pickly.service.notification.service.dto.NotificationStandardDTO
+import org.pickly.service.notification.service.interfaces.NotificationStandardService
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+import org.testcontainers.junit.jupiter.Testcontainers
+import spock.lang.Specification
+
+import java.time.LocalTime
+
+@Transactional
+@SpringBootTest
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ActiveProfiles("test")
+class NotificationStandardServiceSpec extends Specification {
+
+    @Autowired
+    private NotificationStandardService notificationStandardService
+
+    @Autowired
+    private NotificationStandardRepository notificationStandardRepository
+
+    @Autowired
+    private MemberRepository memberRepository
+
+    private NotificationStandardFactory notificationStandardFactory = new NotificationStandardFactory()
+    private MemberFactory memberFactory = new MemberFactory()
+
+    @BeforeEach
+    void setup() {
+        notificationStandardRepository.deleteAll()
+        memberRepository.deleteAll()
+    }
+
+    def "알림 설정이 없는 경우 생성할 수 있다"() {
+        given:
+        var member = memberRepository.save(memberFactory.testMember())
+
+        when:
+        notificationStandardService.createNotificationStandard(
+                member.id,
+                new NotificationStandardDTO(true, LocalTime.of(9, 0))
+        )
+
+        then:
+        var found = notificationStandardService.findByMemberId(member.id)
+        found.isActive == true
+        found.notifyDailyAt == LocalTime.of(9, 0)
+    }
+
+    def "사용자가 이미 알림 설정을 가지고 있는 경우 생성할 수 없다"() {
+        given:
+        var member = memberRepository.save(memberFactory.testMember())
+        notificationStandardService.createNotificationStandard(
+                member.id,
+                new NotificationStandardDTO(true, LocalTime.of(9, 0))
+        )
+
+        when:
+        notificationStandardService.createNotificationStandard(
+                member.id,
+                new NotificationStandardDTO(true, LocalTime.of(9, 0))
+        )
+
+        then:
+        thrown(BusinessException)
+    }
+
+    def "사용자가 알림 설정을 이미 가지고 있는 경우 수정할 수 있다"() {
+        given:
+        var member = memberRepository.save(memberFactory.testMember())
+        notificationStandardRepository.save(notificationStandardFactory.testNotificationStandard(member))
+
+        when:
+        notificationStandardService.updateNotificationStandard(
+                member.id,
+                new NotificationStandardDTO(false, LocalTime.of(10, 0))
+        )
+
+        then:
+        var found = notificationStandardService.findByMemberId(member.id)
+        found.isActive == false
+        found.notifyDailyAt == LocalTime.of(10, 0)
+    }
+
+    def "사용자가 알림 설정을 가지고 있지 않은 경우 수정할 수 없다"() {
+        given:
+        var member = memberRepository.save(memberFactory.testMember())
+
+        when:
+        notificationStandardService.updateNotificationStandard(
+                member.id,
+                new NotificationStandardDTO(false, LocalTime.of(10, 0))
+        )
+
+        then:
+        thrown(BusinessException)
+    }
+}

--- a/pickly-service/src/test/resources/schema.sql
+++ b/pickly-service/src/test/resources/schema.sql
@@ -162,7 +162,7 @@ create table notification_standard
         constraint bookmark_member_id_fk
         references member
         on update cascade on delete cascade,
-    standard_date integer   default 7     not null,
+    notify_daily_at time                  not null,
     is_active     boolean                 not null,
     created_at    timestamp default now() not null,
     updated_at    timestamp,


### PR DESCRIPTION
## 📌 개요 (필수)

알림 기준 설정 API를 추가합니다.

Resolves #113.

<br>

## 🔨 작업 사항 (필수)

- `GET /api/notification-standards/me` : 조회
- `POST /api/notification-standards` : 생성
- `PUT /api/notification-standards/me` : 수정

<br>

## ⚡️ 관심 리뷰 (선택)

처음엔 알림 기준이 없어서 오류가 날텐데... upsert 또는 조회할 때 생성하는 느낌으로 해야할지 고민이긴 합니다 🤔

GET 요청 -> 생성 여부 조회 -> 없으면 생성 후 조회 (활성화 false, 아침 9시)
PUT 요청 -> 생성 여부 조회 -> 없으면 오류, 있으면 수정
(POST 요청은 삭제)

이렇게 가는건 어떨까요? @pickly-team/backend-team 
