### PR TITLE
[feat] category 다수 생성 API, 순서 수정 AP

### DIFF
--- a/pickly-common/src/main/java/org/pickly/common/error/ErrorResponse.java
+++ b/pickly-common/src/main/java/org/pickly/common/error/ErrorResponse.java
@@ -16,75 +16,81 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ErrorResponse {
 
-    private String message;
-    private int status;
-    private List<FieldError> errors;
-    private String code;
+  private String message;
+  private int status;
+  private List<FieldError> errors;
+  private String code;
 
 
-    private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
-        this.message = code.getMessage();
-        this.status = code.getStatus();
-        this.errors = errors;
-        this.code = code.getCode();
+  private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+    this.message = code.getMessage();
+    this.status = code.getStatus();
+    this.errors = errors;
+    this.code = code.getCode();
+  }
+
+  private ErrorResponse(final ErrorCode code) {
+    this.message = code.getMessage();
+    this.status = code.getStatus();
+    this.code = code.getCode();
+    this.errors = new ArrayList<>();
+  }
+
+  public ErrorResponse(final ErrorCode code, final String message) {
+    this.message = message;
+    this.status = code.getStatus();
+    this.code = code.getCode();
+  }
+
+
+  public static ErrorResponse of(final ErrorCode code, final
+  BindingResult bindingResult) {
+    return new ErrorResponse(code, FieldError.of(bindingResult));
+  }
+
+  public static ErrorResponse of(final ErrorCode code) {
+    return new ErrorResponse(code);
+  }
+
+  public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
+    return new ErrorResponse(code, errors);
+  }
+
+  public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+    final String value = e.getValue() == null ? "" : e.getValue().toString();
+    final List<FieldError> errors = FieldError.of(e.getName(), value, e.getErrorCode());
+    return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE, errors);
+  }
+
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class FieldError {
+    private String field;
+    private String value;
+    private String reason;
+
+    private FieldError(final String field, final String value, final String reason) {
+      this.field = field;
+      this.value = value;
+      this.reason = reason;
     }
 
-    private ErrorResponse(final ErrorCode code) {
-        this.message = code.getMessage();
-        this.status = code.getStatus();
-        this.code = code.getCode();
-        this.errors = new ArrayList<>();
+    public static List<FieldError> of(final String field, final String value, final String reason) {
+      List<FieldError> fieldErrors = new ArrayList<>();
+      fieldErrors.add(new FieldError(field, value, reason));
+      return fieldErrors;
     }
 
-
-    public static ErrorResponse of(final ErrorCode code, final
-    BindingResult bindingResult) {
-        return new ErrorResponse(code, FieldError.of(bindingResult));
+    private static List<FieldError> of(final BindingResult bindingResult) {
+      final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+      return fieldErrors.stream()
+          .map(error -> new FieldError(
+              error.getField(),
+              error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+              error.getDefaultMessage()))
+          .collect(Collectors.toList());
     }
-
-    public static ErrorResponse of(final ErrorCode code) {
-        return new ErrorResponse(code);
-    }
-
-    public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
-        return new ErrorResponse(code, errors);
-    }
-
-    public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
-        final String value = e.getValue() == null ? "" : e.getValue().toString();
-        final List<FieldError> errors = FieldError.of(e.getName(), value, e.getErrorCode());
-        return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE, errors);
-    }
-
-
-    @Getter
-    @NoArgsConstructor(access = AccessLevel.PROTECTED)
-    public static class FieldError {
-        private String field;
-        private String value;
-        private String reason;
-
-        private FieldError(final String field, final String value, final String reason) {
-            this.field = field;
-            this.value = value;
-            this.reason = reason;
-        }
-
-        public static List<FieldError> of(final String field, final String value, final String reason) {
-            List<FieldError> fieldErrors = new ArrayList<>();
-            fieldErrors.add(new FieldError(field, value, reason));
-            return fieldErrors;
-        }
-
-        private static List<FieldError> of(final BindingResult bindingResult) {
-            final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
-            return fieldErrors.stream()
-                    .map(error -> new FieldError(
-                            error.getField(),
-                            error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
-                            error.getDefaultMessage()))
-                    .collect(Collectors.toList());
-        }
-    }
+  }
 
 }

--- a/pickly-service/Dockerfile
+++ b/pickly-service/Dockerfile
@@ -19,5 +19,5 @@ FROM openjdk:17-oracle
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} app.jar
 COPY wait-for-it.sh /usr/local/bin/
-ENTRYPOINT ["wait-for-it.sh", "db:5432", "--", "java", "-jar", "-Dspring.profiles.active=dev","app.jar"]
+ENTRYPOINT ["wait-for-it.sh", "db:5432", "--", "java", "-jar", "-Dspring.profiles.active=local","app.jar"]
 

--- a/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
@@ -3,29 +3,19 @@ package org.pickly.service.category.controller;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.pickly.service.category.dto.controller.CategoryMapper;
 import org.pickly.service.category.dto.controller.CategoryRequestDTO;
 import org.pickly.service.category.dto.controller.CategoryResponseDTO;
 import org.pickly.service.category.dto.controller.CategoryUpdateRequestDTO;
-import org.pickly.service.category.entity.Category;
 import org.pickly.service.category.dto.service.CategoryDTO;
+import org.pickly.service.category.entity.Category;
 import org.pickly.service.category.service.interfaces.CategoryService;
-import org.pickly.service.common.utils.page.PageRequest;
 import org.pickly.service.common.utils.page.PageResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import version.VersionResource;
-import org.pickly.service.category.service.interfaces.CategoryService;
-import org.pickly.service.common.version.ApiVersion;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,7 +26,8 @@ public class CategoryController {
 
   @PostMapping("/categories")
   public ResponseEntity<CategoryResponseDTO> create(
-      @RequestBody @Valid final CategoryRequestDTO dto) {
+      @RequestBody @Valid final CategoryRequestDTO dto
+  ) {
     Category category = categoryService.create(dto);
 
     return ResponseEntity

--- a/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
@@ -1,6 +1,11 @@
 package org.pickly.service.category.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +27,11 @@ public class CategoryController {
 
   private final CategoryService categoryService;
 
+  @Operation(summary = "카테고리 생성 (동시에 다수의 카테고리 생성 가능)")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 ID"),
+  })
   @PostMapping("/categories")
   public void create(
       @Parameter(name = "memberId", description = "유저 ID 값", example = "1", required = true)
@@ -34,6 +44,12 @@ public class CategoryController {
     categoryService.create(memberId, requests);
   }
 
+  @Operation(summary = "특정 카테고리의 이름, 이모지 수정")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공",
+          content = @Content(mediaType = "application/json",
+              schema = @Schema(implementation = CategoryResponseDTO.class)))
+  })
   @PutMapping("/categories/{categoryId}")
   public ResponseEntity<CategoryResponseDTO> update(
       @PathVariable @Positive Long categoryId,
@@ -45,6 +61,11 @@ public class CategoryController {
         .ok(CategoryMapper.toResponseDTO(category));
   }
 
+  @Operation(summary = "다수의 카테고리의 순서 수정")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 순서값 입력"),
+  })
   @PatchMapping("/categories/order-num")
   public void updateOrderNum(
       @RequestBody @Valid
@@ -54,6 +75,11 @@ public class CategoryController {
     categoryService.updateOrderNum(requests);
   }
 
+  @Operation(summary = "특정 카테고리 삭제")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 카테고리"),
+  })
   @DeleteMapping("/categories/{categoryId}")
   public ResponseEntity<Void> delete(
       @PathVariable Long categoryId
@@ -64,6 +90,11 @@ public class CategoryController {
         .build();
   }
 
+  @Operation(summary = "다수의 카테고리 삭제")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "400", description = "존재하지 않는 카테고리"),
+  })
   @DeleteMapping("/categories")
   public ResponseEntity<Void> deleteAllById(
       @RequestParam(value = "categoryId") List<Long> categoryIds
@@ -74,6 +105,12 @@ public class CategoryController {
         .build();
   }
 
+  @Operation(summary = "특정 유저의 카테고리 전체 조회. 페이지네이션 적용")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공",
+          content = @Content(mediaType = "application/json",
+              schema = @Schema(implementation = PageResponse.class)))
+  })
   @GetMapping("/categories")
   public PageResponse<CategoryDTO> getCategoryByMember(
       @Parameter(name = "memberId", description = "유저 ID 값", example = "1", required = true)
@@ -88,6 +125,12 @@ public class CategoryController {
     return categoryService.getCategoriesByMember(cursorId, pageSize, memberId);
   }
 
+  @Operation(summary = "특정 유저의 전체 카테고리 수 조회")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공",
+          content = @Content(mediaType = "application/json",
+              schema = @Schema(implementation = Integer.class)))
+  })
   @GetMapping("/categories/cnt")
   public ResponseEntity<Integer> getCategoryCntByMember(
       @RequestParam(value = "memberId") Long memberId

--- a/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
@@ -5,10 +5,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Length;
-import org.pickly.service.category.dto.controller.CategoryMapper;
-import org.pickly.service.category.dto.controller.CategoryRequestDTO;
-import org.pickly.service.category.dto.controller.CategoryResponseDTO;
-import org.pickly.service.category.dto.controller.CategoryUpdateRequestDTO;
+import org.pickly.service.category.dto.controller.*;
 import org.pickly.service.category.dto.service.CategoryDTO;
 import org.pickly.service.category.entity.Category;
 import org.pickly.service.category.service.interfaces.CategoryService;
@@ -46,6 +43,15 @@ public class CategoryController {
 
     return ResponseEntity
         .ok(CategoryMapper.toResponseDTO(category));
+  }
+
+  @PatchMapping("/categories/order-num")
+  public void updateOrderNum(
+      @RequestBody @Valid
+      @Length(min = 1, message = "최소 1개의 카테고리 정보를 입력해주세요.")
+      final List<CategoryOrderNumUpdateReq> requests
+  ) {
+    categoryService.updateOrderNum(requests);
   }
 
   @DeleteMapping("/categories/{categoryId}")

--- a/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
@@ -34,7 +34,7 @@ public class CategoryController {
         .ok(CategoryMapper.toResponseDTO(category));
   }
 
-  @PostMapping("/categories/{categoryId}")
+  @PutMapping("/categories/{categoryId}")
   public ResponseEntity<CategoryResponseDTO> update(
       @PathVariable @Positive Long categoryId,
       @RequestBody @Valid final CategoryUpdateRequestDTO dto

--- a/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
@@ -25,13 +25,13 @@ public class CategoryController {
   private final CategoryService categoryService;
 
   @PostMapping("/categories")
-  public ResponseEntity<CategoryResponseDTO> create(
-      @RequestBody @Valid final CategoryRequestDTO dto
-  ) {
-    Category category = categoryService.create(dto);
+  public void create(
+      @Parameter(name = "memberId", description = "유저 ID 값", example = "1", required = true)
+      @Positive(message = "유저 ID는 양수입니다.") final Long memberId,
 
-    return ResponseEntity
-        .ok(CategoryMapper.toResponseDTO(category));
+      @RequestBody @Valid final List<CategoryRequestDTO> requests
+  ) {
+    categoryService.create(memberId, requests);
   }
 
   @PutMapping("/categories/{categoryId}")

--- a/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/controller/CategoryController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
 import org.pickly.service.category.dto.controller.CategoryMapper;
 import org.pickly.service.category.dto.controller.CategoryRequestDTO;
 import org.pickly.service.category.dto.controller.CategoryResponseDTO;
@@ -29,7 +30,9 @@ public class CategoryController {
       @Parameter(name = "memberId", description = "유저 ID 값", example = "1", required = true)
       @Positive(message = "유저 ID는 양수입니다.") final Long memberId,
 
-      @RequestBody @Valid final List<CategoryRequestDTO> requests
+      @RequestBody @Valid
+      @Length(min = 1, message = "최소 1개의 카테고리 정보를 입력해주세요.")
+      final List<CategoryRequestDTO> requests
   ) {
     categoryService.create(memberId, requests);
   }

--- a/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryMapper.java
@@ -7,8 +7,8 @@ public class CategoryMapper {
   public static CategoryResponseDTO toResponseDTO(final Category category) {
     return new CategoryResponseDTO(
         category.getId(),
-        category.getMember().getId(),
-        category.getName()
+        category.getName(),
+        category.getEmoji()
     );
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryOrderNumUpdateReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryOrderNumUpdateReq.java
@@ -1,0 +1,21 @@
+package org.pickly.service.category.dto.controller;
+
+import jakarta.validation.constraints.Positive;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CategoryOrderNumUpdateReq {
+
+  @Positive(message = "카테고리 ID (PK)는 양수입니다.")
+  private Long categoryId;
+
+  @Positive(message = "카테고리 순서는 양수입니다.")
+  private Integer orderNum;
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryRequestDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryRequestDTO.java
@@ -2,11 +2,16 @@ package org.pickly.service.category.dto.controller;
 
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
+import org.pickly.service.common.utils.validator.EmojiCheck;
 
 public record CategoryRequestDTO(
-    @Positive
+    @Positive(message = "멤버 ID는 양수입니다.")
     Long memberId,
-    @NotEmpty
-    String name
+    @NotEmpty(message = "카테고리 이름을 입력해주세요.")
+    String name,
+
+    @EmojiCheck
+    @NotEmpty(message = "카테고리 emoji를 입력해주세요.")
+    String emoji
 ){
 }

--- a/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryRequestDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryRequestDTO.java
@@ -1,12 +1,9 @@
 package org.pickly.service.category.dto.controller;
 
 import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Positive;
 import org.pickly.service.common.utils.validator.EmojiCheck;
 
 public record CategoryRequestDTO(
-    @Positive(message = "멤버 ID는 양수입니다.")
-    Long memberId,
     @NotEmpty(message = "카테고리 이름을 입력해주세요.")
     String name,
 

--- a/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryResponseDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryResponseDTO.java
@@ -2,7 +2,7 @@ package org.pickly.service.category.dto.controller;
 
 public record CategoryResponseDTO(
   long categoryId,
-  long memberId,
-  String name
+  String name,
+  String emoji
   ){
 }

--- a/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryUpdateRequestDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/dto/controller/CategoryUpdateRequestDTO.java
@@ -1,8 +1,16 @@
 package org.pickly.service.category.dto.controller;
 
+import jakarta.validation.constraints.NotEmpty;
+import org.pickly.service.common.utils.validator.EmojiCheck;
+
 public record CategoryUpdateRequestDTO(
-    Boolean isAutoDeleteMode,
+
+    @NotEmpty(message = "카테고리 이름을 입력해주세요.")
     String name,
+
+    @EmojiCheck
+    @NotEmpty(message = "카테고리 emoji를 입력해주세요.")
     String emoji
+    
 ) {
 }

--- a/pickly-service/src/main/java/org/pickly/service/category/dto/service/CategoryDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/dto/service/CategoryDTO.java
@@ -11,14 +11,16 @@ import org.pickly.service.category.entity.Category;
 public class CategoryDTO {
 
   private long categoryId;
-  private long memberId;
   private String name;
+  private String emoji;
+  private Integer orderNum;
 
   public static CategoryDTO from(final Category category) {
     return CategoryDTO.builder()
         .categoryId(category.getId())
-        .memberId(category.getMember().getId())
         .name(category.getName())
+        .emoji(category.getEmoji())
+        .orderNum(category.getOrderNum())
         .build();
   }
 }

--- a/pickly-service/src/main/java/org/pickly/service/category/entity/Category.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/entity/Category.java
@@ -35,6 +35,9 @@ public class Category extends BaseEntity {
   @Column(columnDefinition = "text")
   private String emoji;
 
+  @Column(name = "order_num", nullable = false)
+  private Integer orderNum;
+
   public Category update(Boolean isAutoDeleteMode, String name, String emoji) {
     this.isAutoDeleteMode = isAutoDeleteMode;
     this.name = name;

--- a/pickly-service/src/main/java/org/pickly/service/category/entity/Category.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/entity/Category.java
@@ -26,9 +26,6 @@ public class Category extends BaseEntity {
   @JoinColumn(name = "member_id")
   private Member member;
 
-  @Column(name = "is_auto_delete_mode", nullable = false)
-  private Boolean isAutoDeleteMode;
-
   @Column(length = 100, nullable = false)
   private String name;
 
@@ -38,8 +35,7 @@ public class Category extends BaseEntity {
   @Column(name = "order_num", nullable = false)
   private Integer orderNum;
 
-  public Category update(Boolean isAutoDeleteMode, String name, String emoji) {
-    this.isAutoDeleteMode = isAutoDeleteMode;
+  public Category update(String name, String emoji) {
     this.name = name;
     this.emoji = emoji;
 

--- a/pickly-service/src/main/java/org/pickly/service/category/exception/CategoryExceptionHandler.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/exception/CategoryExceptionHandler.java
@@ -1,5 +1,21 @@
 package org.pickly.service.category.exception;
 
+import org.pickly.common.error.ErrorResponse;
+import org.pickly.common.error.exception.ErrorCode;
+import org.pickly.service.category.exception.custom.CategoryOrderNumDuplicateException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
 public class CategoryExceptionHandler {
+
+  @ExceptionHandler(CategoryOrderNumDuplicateException.class)
+  protected ResponseEntity<ErrorResponse> handleCategoryOrderNumDuplicateException(
+      CategoryOrderNumDuplicateException e) {
+    final ErrorResponse response = new ErrorResponse(ErrorCode.INVALID_INPUT_VALUE, e.getMessage());
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/category/exception/custom/CategoryOrderNumDuplicateException.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/exception/custom/CategoryOrderNumDuplicateException.java
@@ -1,0 +1,7 @@
+package org.pickly.service.category.exception.custom;
+
+public class CategoryOrderNumDuplicateException extends RuntimeException{
+  public CategoryOrderNumDuplicateException() {
+    super("카테고리 순서 입력값이 잘못되었습니다.");
+  }
+}

--- a/pickly-service/src/main/java/org/pickly/service/category/exception/custom/CategoryOrderNumDuplicateException.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/exception/custom/CategoryOrderNumDuplicateException.java
@@ -1,6 +1,6 @@
 package org.pickly.service.category.exception.custom;
 
-public class CategoryOrderNumDuplicateException extends RuntimeException{
+public class CategoryOrderNumDuplicateException extends RuntimeException {
   public CategoryOrderNumDuplicateException() {
     super("카테고리 순서 입력값이 잘못되었습니다.");
   }

--- a/pickly-service/src/main/java/org/pickly/service/category/repository/impl/CategoryJdbcRepositoryImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/repository/impl/CategoryJdbcRepositoryImpl.java
@@ -1,0 +1,40 @@
+package org.pickly.service.category.repository.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.pickly.service.category.entity.Category;
+import org.pickly.service.category.repository.interfaces.CategoryJdbcRepository;
+import org.springframework.jdbc.core.BatchPreparedStatementSetter;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryJdbcRepositoryImpl implements CategoryJdbcRepository {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  @Override
+  public void createCategories(List<Category> categories) {
+    jdbcTemplate.batchUpdate("insert into category" +
+            "(member_id, name, emoji, order_num) values (?, ?, ?, ?)",
+        new BatchPreparedStatementSetter() {
+          @Override
+          public void setValues(PreparedStatement ps, int i) throws SQLException {
+            ps.setLong(1, categories.get(i).getMember().getId());
+            ps.setString(2, categories.get(i).getName());
+            ps.setString(3, categories.get(i).getEmoji());
+            ps.setInt(4, categories.get(i).getOrderNum());
+          }
+
+          @Override
+          public int getBatchSize() {
+            return categories.size();
+          }
+        });
+  }
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/category/repository/impl/CategoryJdbcRepositoryImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/repository/impl/CategoryJdbcRepositoryImpl.java
@@ -1,6 +1,7 @@
 package org.pickly.service.category.repository.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.pickly.service.category.dto.controller.CategoryOrderNumUpdateReq;
 import org.pickly.service.category.entity.Category;
 import org.pickly.service.category.repository.interfaces.CategoryJdbcRepository;
 import org.springframework.jdbc.core.BatchPreparedStatementSetter;
@@ -33,6 +34,23 @@ public class CategoryJdbcRepositoryImpl implements CategoryJdbcRepository {
           @Override
           public int getBatchSize() {
             return categories.size();
+          }
+        });
+  }
+
+  @Override
+  public void updateCategoryOrderNums(List<CategoryOrderNumUpdateReq> reqs) {
+    jdbcTemplate.batchUpdate("update category set order_num = ? where id = ?",
+        new BatchPreparedStatementSetter() {
+          @Override
+          public void setValues(PreparedStatement ps, int i) throws SQLException {
+            ps.setInt(1, reqs.get(i).getOrderNum());
+            ps.setLong(2, reqs.get(i).getCategoryId());
+          }
+
+          @Override
+          public int getBatchSize() {
+            return reqs.size();
           }
         });
   }

--- a/pickly-service/src/main/java/org/pickly/service/category/repository/interfaces/CategoryJdbcRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/repository/interfaces/CategoryJdbcRepository.java
@@ -1,0 +1,11 @@
+package org.pickly.service.category.repository.interfaces;
+
+import org.pickly.service.category.entity.Category;
+
+import java.util.List;
+
+public interface CategoryJdbcRepository {
+
+  void createCategories(List<Category> categories);
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/category/repository/interfaces/CategoryJdbcRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/repository/interfaces/CategoryJdbcRepository.java
@@ -1,5 +1,6 @@
 package org.pickly.service.category.repository.interfaces;
 
+import org.pickly.service.category.dto.controller.CategoryOrderNumUpdateReq;
 import org.pickly.service.category.entity.Category;
 
 import java.util.List;
@@ -7,5 +8,7 @@ import java.util.List;
 public interface CategoryJdbcRepository {
 
   void createCategories(List<Category> categories);
+
+  void updateCategoryOrderNums(List<CategoryOrderNumUpdateReq> reqs);
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/category/repository/interfaces/CategoryRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/repository/interfaces/CategoryRepository.java
@@ -1,19 +1,21 @@
 package org.pickly.service.category.repository.interfaces;
 
-import java.util.List;
-import java.util.Optional;
 import org.pickly.service.category.entity.Category;
-import org.pickly.service.common.utils.page.PageRequest;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    @Override
     @EntityGraph(attributePaths = {"member"})
     Optional<Category> findById(Long id);
+
+    @Query("select c from Category c where c.member.id = :memberId order by c.createdAt desc limit 1")
+    Category findLastCategoryByMemberId(@Param("memberId") Long memberId);
 
     @Modifying
     @Query("SELECT c FROM Category c WHERE c.id IN :ids")

--- a/pickly-service/src/main/java/org/pickly/service/category/service/impl/CategoryServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/service/impl/CategoryServiceImpl.java
@@ -70,7 +70,6 @@ public class CategoryServiceImpl implements CategoryService {
   @Transactional
   public void updateOrderNum(List<CategoryOrderNumUpdateReq> requests) {
 
-    // {categoryId, orderNum} UK가 걸려있으므로 request에서만 중복 체크해주면 OK
     if (!checkOrderNumUnique(requests)) {
       throw new CategoryOrderNumDuplicateException();
     }
@@ -85,10 +84,12 @@ public class CategoryServiceImpl implements CategoryService {
 
   private boolean checkOrderNumUnique(List<CategoryOrderNumUpdateReq> requests) {
     Set<Integer> orderNums = new HashSet<>();
+    Set<Long> categoryIds = new HashSet<>();
     for (CategoryOrderNumUpdateReq req : requests) {
       orderNums.add(req.getOrderNum());
+      categoryIds.add(req.getCategoryId());
     }
-    return orderNums.size() == requests.size();
+    return orderNums.size() == requests.size() && categoryIds.size() == requests.size();
   }
 
   @Transactional

--- a/pickly-service/src/main/java/org/pickly/service/category/service/impl/CategoryServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/service/impl/CategoryServiceImpl.java
@@ -9,6 +9,7 @@ import org.pickly.service.category.repository.interfaces.CategoryJdbcRepository;
 import org.pickly.service.category.repository.interfaces.CategoryQueryRepository;
 import org.pickly.service.category.repository.interfaces.CategoryRepository;
 import org.pickly.service.category.service.interfaces.CategoryService;
+import org.pickly.service.common.utils.base.BaseEntity;
 import org.pickly.service.common.utils.page.PageRequest;
 import org.pickly.service.common.utils.page.PageResponse;
 import org.pickly.service.member.entity.Member;
@@ -71,10 +72,8 @@ public class CategoryServiceImpl implements CategoryService {
   @Transactional
   public void deleteAllByCategoryId(List<Long> ids) {
     List<Category> categories = categoryRepository.findAllByCategoryId(ids);
-    categories.stream().forEach(category -> category.delete());
+    categories.forEach(BaseEntity::delete);
   }
-
-
 
   @Override
   public Integer getCategoryCntByMember(Long memberId) {
@@ -86,14 +85,17 @@ public class CategoryServiceImpl implements CategoryService {
   public PageResponse<CategoryDTO> getCategoriesByMember(
       final Long cursorId,
       final Integer pageSize, 
-      final Long memberId) {
+      final Long memberId
+  ) {
     PageRequest pageRequest = makePageRequest(cursorId, pageSize);
     List<Category> categories = categoryQueryRepository.findAllByMemberId(pageRequest, memberId);
     return makeResponse(pageRequest.getPageSize(), categories);
   }
 
-  private <T> List<T> mapToDtoList(final List<Category> categories,
-      final Function<Category, T> mapper) {
+  private <T> List<T> mapToDtoList(
+      final List<Category> categories,
+      final Function<Category, T> mapper
+  ) {
     return categories.stream().map(mapper).toList();
   }
 
@@ -104,9 +106,11 @@ public class CategoryServiceImpl implements CategoryService {
     return new PageResponse<>(contentSize, pageSize, contents);
   }
 
-  private List<Category> removeElement(final List<Category> categoryList,
+  private List<Category> removeElement(
+      final List<Category> categoryList,
       final int size,
-      final int pageSize) {
+      final int pageSize
+  ) {
     if (size - LAST_ITEM >= pageSize) {
       List<Category> resultList = new ArrayList<>(categoryList);
       resultList.remove(size - LAST_ITEM);

--- a/pickly-service/src/main/java/org/pickly/service/category/service/impl/CategoryServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/service/impl/CategoryServiceImpl.java
@@ -1,8 +1,5 @@
 package org.pickly.service.category.service.impl;
 
-import java.util.List;
-import java.util.ArrayList;
-import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.pickly.service.category.dto.controller.CategoryRequestDTO;
 import org.pickly.service.category.dto.controller.CategoryUpdateRequestDTO;
@@ -18,6 +15,10 @@ import org.pickly.service.member.exception.custom.MemberNotFoundException;
 import org.pickly.service.member.repository.interfaces.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
 
 @Service
 @RequiredArgsConstructor
@@ -35,7 +36,7 @@ public class CategoryServiceImpl implements CategoryService {
     Member member = memberRepository.findById(dto.memberId())
         .orElseThrow(() -> new MemberNotFoundException(dto.memberId()));
 
-    return categoryRepository.save(new Category(member, false, dto.name(), ""));
+    return categoryRepository.save(new Category(member, false, dto.name(), "", 1));
   }
 
   @Transactional

--- a/pickly-service/src/main/java/org/pickly/service/category/service/interfaces/CategoryService.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/service/interfaces/CategoryService.java
@@ -1,15 +1,16 @@
 package org.pickly.service.category.service.interfaces;
 
-import java.util.List;
 import org.pickly.service.category.dto.controller.CategoryRequestDTO;
 import org.pickly.service.category.dto.controller.CategoryUpdateRequestDTO;
 import org.pickly.service.category.dto.service.CategoryDTO;
 import org.pickly.service.category.entity.Category;
 import org.pickly.service.common.utils.page.PageResponse;
 
+import java.util.List;
+
 public interface CategoryService {
 
-    Category create(CategoryRequestDTO request);
+    void create(Long memberId, List<CategoryRequestDTO> requests);
 
     Category update(Long categoryId, CategoryUpdateRequestDTO dto);
 

--- a/pickly-service/src/main/java/org/pickly/service/category/service/interfaces/CategoryService.java
+++ b/pickly-service/src/main/java/org/pickly/service/category/service/interfaces/CategoryService.java
@@ -1,5 +1,6 @@
 package org.pickly.service.category.service.interfaces;
 
+import org.pickly.service.category.dto.controller.CategoryOrderNumUpdateReq;
 import org.pickly.service.category.dto.controller.CategoryRequestDTO;
 import org.pickly.service.category.dto.controller.CategoryUpdateRequestDTO;
 import org.pickly.service.category.dto.service.CategoryDTO;
@@ -13,6 +14,8 @@ public interface CategoryService {
     void create(Long memberId, List<CategoryRequestDTO> requests);
 
     Category update(Long categoryId, CategoryUpdateRequestDTO dto);
+
+    void updateOrderNum(List<CategoryOrderNumUpdateReq> requests);
 
     void delete(Long categoryId);
 

--- a/pickly-service/src/main/java/org/pickly/service/common/utils/validator/EmojiCheck.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/utils/validator/EmojiCheck.java
@@ -1,0 +1,21 @@
+package org.pickly.service.common.utils.validator;
+
+import jakarta.validation.Constraint;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = EmojiValidator.class)
+public @interface EmojiCheck {
+
+  String message() default "이모지가 아닙니다.";
+
+  Class[] groups() default {};
+
+  Class[] payload() default {};
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/common/utils/validator/EmojiValidator.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/utils/validator/EmojiValidator.java
@@ -1,0 +1,42 @@
+package org.pickly.service.common.utils.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class EmojiValidator implements ConstraintValidator<EmojiCheck, String> {
+
+  @Override
+  public boolean isValid(String emoji, ConstraintValidatorContext context) {
+
+    if (checkIsEmpty(emoji)) {
+      return false;
+    }
+
+    if (checkCodePointCount(emoji)) {
+      return false;
+    }
+
+    int codePoint = emoji.codePointAt(0);
+    return isEmoji(codePoint);
+  }
+
+  private static boolean checkIsEmpty(String value) {
+    return value == null || value.length() == 0;
+  }
+
+  private static boolean checkCodePointCount(String value) {
+    int codePointCnt = value.codePointCount(0, value.length());
+    return codePointCnt > 1;
+  }
+
+  private static boolean isEmoji(int codePoint) {
+    return (codePoint == 0x0)
+        || (codePoint == 0x9)
+        || (codePoint == 0xA)
+        || (codePoint == 0xD)
+        || ((codePoint >= 0x20) && (codePoint <= 0xD7FF))
+        || ((codePoint >= 0xE000) && (codePoint <= 0xFFFD))
+        || ((codePoint >= 0x10000) && (codePoint <= 0x10FFFF));
+  }
+
+}

--- a/pickly-service/src/main/resources/data.sql
+++ b/pickly-service/src/main/resources/data.sql
@@ -4,9 +4,9 @@ VALUES ('test', 'helpme', true, 'test@gmail.com', '테스트1', '테스트1', '�
        ('test2', 'ohmygod', false, 'test2@gmail.com', '테스트2', '테스트2', '😳', null);
 
 INSERT INTO category
-    (member_id, is_auto_delete_mode, name, emoji)
-VALUES (1, true, '백엔드', '😎'),
-       (1, false, '프론트엔드', '😳');
+    (member_id, is_auto_delete_mode, name, order_num, emoji)
+VALUES (1, true, '백엔드', 1, '😎'),
+       (1, false, '프론트엔드', 2, '😳');
 
 INSERT INTO bookmark
 (category_id, member_id, url, title, preview_image_url, is_user_like, read_by_user, visibility)

--- a/pickly-service/src/main/resources/data.sql
+++ b/pickly-service/src/main/resources/data.sql
@@ -4,9 +4,9 @@ VALUES ('test', 'helpme', true, 'test@gmail.com', '테스트1', '테스트1', '�
        ('test2', 'ohmygod', false, 'test2@gmail.com', '테스트2', '테스트2', '😳', null);
 
 INSERT INTO category
-    (member_id, is_auto_delete_mode, name, order_num, emoji)
-VALUES (1, true, '백엔드', 1, '😎'),
-       (1, false, '프론트엔드', 2, '😳');
+    (member_id, name, order_num, emoji)
+VALUES (1, '백엔드', 1, '😎'),
+       (1, '프론트엔드', 2, '😳');
 
 INSERT INTO bookmark
 (category_id, member_id, url, title, preview_image_url, is_user_like, read_by_user, visibility)

--- a/pickly-service/src/main/resources/data.sql
+++ b/pickly-service/src/main/resources/data.sql
@@ -29,7 +29,7 @@ VALUES (1, 2, false),
 
 -- notify_daily_at is  time without timezone
 INSERT INTO notification_standard
-    (member_id, notify_daily_at, notify_daily_at, is_active)
+    (member_id, notify_standard_day, notify_daily_at, is_active)
 VALUES (1, 3, '09:00:00', true),
        (2, 7, '18:00:00', false);
 

--- a/pickly-service/src/main/resources/schema.sql
+++ b/pickly-service/src/main/resources/schema.sql
@@ -65,8 +65,7 @@ create table category
     order_num           integer                 not null,
     created_at          timestamp default now() not null,
     updated_at          timestamp,
-    deleted_at          timestamp,
-    constraint category_order_uk unique (id, order_num)
+    deleted_at          timestamp
 );
 
 create trigger update_trigger

--- a/pickly-service/src/main/resources/schema.sql
+++ b/pickly-service/src/main/resources/schema.sql
@@ -66,7 +66,7 @@ create table category
     created_at          timestamp default now() not null,
     updated_at          timestamp,
     deleted_at          timestamp,
-    constraint category_order_uk unique (id, order_num);
+    constraint category_order_uk unique (id, order_num)
 );
 
 create trigger update_trigger

--- a/pickly-service/src/main/resources/schema.sql
+++ b/pickly-service/src/main/resources/schema.sql
@@ -63,7 +63,7 @@ create table category
     is_auto_delete_mode boolean                 not null,
     name                varchar(100)            not null,
     emoji               text,
-    order_number        integer                 not null,
+    order_num           integer                 not null,
     created_at          timestamp default now() not null,
     updated_at          timestamp,
     deleted_at          timestamp

--- a/pickly-service/src/main/resources/schema.sql
+++ b/pickly-service/src/main/resources/schema.sql
@@ -60,7 +60,6 @@ create table category
         constraint category_member_id_fk
             references member
             on update cascade on delete cascade,
-    is_auto_delete_mode boolean                 not null,
     name                varchar(100)            not null,
     emoji               text,
     order_num           integer                 not null,

--- a/pickly-service/src/main/resources/schema.sql
+++ b/pickly-service/src/main/resources/schema.sql
@@ -65,7 +65,8 @@ create table category
     order_num           integer                 not null,
     created_at          timestamp default now() not null,
     updated_at          timestamp,
-    deleted_at          timestamp
+    deleted_at          timestamp,
+    constraint category_order_uk unique (id, order_num);
 );
 
 create trigger update_trigger

--- a/pickly-service/src/main/resources/schema.sql
+++ b/pickly-service/src/main/resources/schema.sql
@@ -63,6 +63,7 @@ create table category
     is_auto_delete_mode boolean                 not null,
     name                varchar(100)            not null,
     emoji               text,
+    order_number        integer                 not null,
     created_at          timestamp default now() not null,
     updated_at          timestamp,
     deleted_at          timestamp

--- a/pickly-service/src/test/groovy/org/pickly/service/category/CategoryFactory.java
+++ b/pickly-service/src/test/groovy/org/pickly/service/category/CategoryFactory.java
@@ -12,7 +12,6 @@ public class CategoryFactory {
   public Category testCategory(Member member) {
     return Category.builder()
         .member(member)
-        .isAutoDeleteMode(false)
         .name("당장 내일 안으로 읽어야 하는 자바 면접 질문")
         .orderNum(1)
         .build();

--- a/pickly-service/src/test/groovy/org/pickly/service/category/CategoryFactory.java
+++ b/pickly-service/src/test/groovy/org/pickly/service/category/CategoryFactory.java
@@ -1,8 +1,5 @@
 package org.pickly.service.category;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.pickly.service.category.entity.Category;
 import org.pickly.service.member.MemberFactory;
 import org.pickly.service.member.entity.Member;
@@ -17,18 +14,8 @@ public class CategoryFactory {
         .member(member)
         .isAutoDeleteMode(false)
         .name("당장 내일 안으로 읽어야 하는 자바 면접 질문")
+        .orderNum(1)
         .build();
-  }
-
-
-  public List<Category> testCategories(int amount) {
-    return IntStream.rangeClosed(1, amount)
-        .mapToObj(i -> Category.builder()
-            .member(memberFactory.testMember())
-            .isAutoDeleteMode(false)
-            .name("당장 내일 안으로 읽어야 하는 자바 면접 질문" + i)
-            .build())
-        .collect(Collectors.toList());
   }
 
 }

--- a/pickly-service/src/test/resources/schema.sql
+++ b/pickly-service/src/test/resources/schema.sql
@@ -65,8 +65,7 @@ create table category
     order_num           integer                 not null,
     created_at          timestamp default now() not null,
     updated_at          timestamp,
-    deleted_at          timestamp,
-    constraint category_order_uk unique (id, order_num)
+    deleted_at          timestamp
 );
 
 create trigger update_trigger

--- a/pickly-service/src/test/resources/schema.sql
+++ b/pickly-service/src/test/resources/schema.sql
@@ -66,7 +66,7 @@ create table category
     created_at          timestamp default now() not null,
     updated_at          timestamp,
     deleted_at          timestamp,
-    constraint category_order_uk unique (id, order_num);
+    constraint category_order_uk unique (id, order_num)
 );
 
 create trigger update_trigger

--- a/pickly-service/src/test/resources/schema.sql
+++ b/pickly-service/src/test/resources/schema.sql
@@ -63,7 +63,7 @@ create table category
     is_auto_delete_mode boolean                 not null,
     name                varchar(100)            not null,
     emoji               text,
-    order_number        integer                 not null,
+    order_num           integer                 not null,
     created_at          timestamp default now() not null,
     updated_at          timestamp,
     deleted_at          timestamp

--- a/pickly-service/src/test/resources/schema.sql
+++ b/pickly-service/src/test/resources/schema.sql
@@ -60,7 +60,6 @@ create table category
         constraint category_member_id_fk
             references member
             on update cascade on delete cascade,
-    is_auto_delete_mode boolean                 not null,
     name                varchar(100)            not null,
     emoji               text,
     order_num           integer                 not null,

--- a/pickly-service/src/test/resources/schema.sql
+++ b/pickly-service/src/test/resources/schema.sql
@@ -65,7 +65,8 @@ create table category
     order_num           integer                 not null,
     created_at          timestamp default now() not null,
     updated_at          timestamp,
-    deleted_at          timestamp
+    deleted_at          timestamp,
+    constraint category_order_uk unique (id, order_num);
 );
 
 create trigger update_trigger

--- a/pickly-service/src/test/resources/schema.sql
+++ b/pickly-service/src/test/resources/schema.sql
@@ -63,6 +63,7 @@ create table category
     is_auto_delete_mode boolean                 not null,
     name                varchar(100)            not null,
     emoji               text,
+    order_number        integer                 not null,
     created_at          timestamp default now() not null,
     updated_at          timestamp,
     deleted_at          timestamp


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #131 , #128 
- 카테고리 관련 내용 수정

<br>

## 🔨 작업 사항 (필수)

-  카테고리 다수 생성 API (= 단일 포함 :: size가 1인 list)
-  카테고리 순서 수정 API
-  카테고리 생성 & 수정 API에 emoji 필드 추가
-  카테고리 수정 API에서 불필요한 필드 삭제
-  카테고리 조회 API에서 불필요한 필드 삭제
-  카테고리 도메인 API에 swagger 주석 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
