### PR TITLE
Firebase Auth Filter가 선택된 URL에 대해서만 적용되도록 합니다.

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/common/config/SwaggerConfig.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/config/SwaggerConfig.java
@@ -1,6 +1,8 @@
 package org.pickly.service.common.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -24,7 +26,14 @@ public class SwaggerConfig {
   @Bean
   public OpenAPI openApi() {
     return new OpenAPI()
+        .components(
+            new Components().addSecuritySchemes("Bearer Authentication", createAPIKeyScheme()))
         .addServersItem(new Server().url("/"));
   }
 
+  private SecurityScheme createAPIKeyScheme() {
+    return new SecurityScheme().type(SecurityScheme.Type.HTTP)
+        .bearerFormat("JWT")
+        .scheme("bearer");
+  }
 }

--- a/pickly-service/src/main/java/org/pickly/service/common/filter/JwtFilter.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/filter/JwtFilter.java
@@ -1,22 +1,32 @@
 package org.pickly.service.common.filter;
 
+import com.google.firebase.auth.FirebaseToken;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.pickly.service.common.utils.base.AuthTokenUtil;
+import org.pickly.service.common.utils.base.RequestUtil;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.filter.OncePerRequestFilter;
 
-//@Component
-//@RequiredArgsConstructor
-//@Slf4j
-//public class JwtFilter extends OncePerRequestFilter {
-//
-//  private final UserDetailsService userDetailsService;
-//  private final AuthTokenUtil authTokenUtil;
-//
-//  @Override
-//  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
-//      FilterChain filterChain)
-//      throws IOException, ServletException {
-//    String bearerToken = RequestUtil.getAuthorizationToken(request.getHeader("Authorization"));
-//    FirebaseToken decodedToken = authTokenUtil.validateToken(bearerToken);
-//
-//    //TODO: decodedToken security context에 저장 필요
-//    filterChain.doFilter(request, response);
-//  }
-//}
+@RequiredArgsConstructor
+@Slf4j
+public class JwtFilter extends OncePerRequestFilter {
+
+  private final UserDetailsService userDetailsService;
+  private final AuthTokenUtil authTokenUtil;
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws IOException, ServletException {
+    String bearerToken = RequestUtil.getAuthorizationToken(request.getHeader("Authorization"));
+    FirebaseToken decodedToken = authTokenUtil.validateToken(bearerToken);
+
+    //TODO: decodedToken security context에 저장 필요
+    filterChain.doFilter(request, response);
+  }
+}


### PR DESCRIPTION
## 📌 개요 (필수)

Firebase Auth Filter가 선택된 URL에 대해서만 적용되도록 합니다.

Resolves #163.

<br>

## 🔨 작업 사항 (필수)

Firebase Auth Filter가 선택된 URL에 대해서만 적용되도록 합니다.

해결 방법:

- `@Component`로 컴포넌트를 등록하지 않고 생성자를 호출해 인증 필터로 주입

- 인증 필터에 대해 `WebSecurityCustomizer`를 만들어 whitelist를 적용


추가로, Swagger에서 버튼을 눌러 Bearer Authorization header를 넣을 수 있도록 했습니다.

![image](https://github.com/pickly-team/pickly-backend/assets/42485462/e1c58f19-48f3-4562-9f07-5e4ccd0b4b17)

<br>

## 🌱 연관 내용 (선택)

원래 원했던 것은 커스텀 어노테이션을 API 위에 붙여 인증하는 것으로 알고 있는데.. 아직 구현이 되어 있지 않습니다.

현재 방식을 그대로 유지한다면 [이 글](https://www.couchcoding.kr/blogs/couchcoding/Firebase%EB%A1%9C%20Google%20%EB%A1%9C%EA%B7%B8%EC%9D%B8%20%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0%202%20(Spring%20%ED%8C%8C%ED%8A%B8))을,

헤더에서 빼오는 방식으로 커스텀 어노테이션을 사용하고 싶다면 [이 글](https://stackoverflow.com/questions/49721779/how-to-add-a-custom-security-annotation-to-spring-mvc-controller-method)을 참고해도 좋을 것 같습니다. 여기에 기능이 좀 더 필요하다면(role 검사) 좀 더 작업이 필요하겠지만요!
 