### PR TITLE
[fix]: firebase 로그인 오류 수정

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
@@ -108,7 +108,8 @@ public class MemberMapper {
         member.getEmail(),
         member.getName(),
         member.getNickname(),
-        member.getPassword()
+        member.getPassword(),
+        member.getId()
     );
   }
 
@@ -128,7 +129,7 @@ public class MemberMapper {
 
   public MemberRegisterRes toMemberRegisterResponse(MemberRegisterDto dto) {
     return new MemberRegisterRes(dto.getUsername(), dto.getIsHardMode(), dto.getEmail(),
-        dto.getName(), dto.getNickname());
+        dto.getName(), dto.getNickname(), dto.getMemberId());
   }
 
   public SearchMemberResultRes toSearchMemberResultRes(SearchMemberResultResDTO dto) {

--- a/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
@@ -119,7 +119,7 @@ public class MemberMapper {
     return Member.builder()
         .username(token.getUid())
         .email(token.getEmail())
-        .name(token.getName())
+        .name(token.getName() == null ? "" : token.getName())
         .nickname("")
         .isHardMode(false)
         .password(password)

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -157,7 +157,7 @@ public class MemberController {
   }
 
   @GetMapping("/id")
-  @Operation(summary = "Refresh token으로 유저 ID를 조회한다.")
+  @Operation(summary = "Access token으로 유저 ID를 조회한다.")
   public ResponseEntity<Long> getMemberId(
       @RequestHeader("Authorization") String authorization) {
     String token = RequestUtil.getAuthorizationToken(authorization);

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -146,6 +146,7 @@ public class MemberController {
   }
 
   @PostMapping("/register")
+  @Operation(summary = "회원가입")
   public ResponseEntity<MemberRegisterRes> register(
       @RequestHeader("Authorization") String authorization) {
     String token = RequestUtil.getAuthorizationToken(authorization);

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -25,6 +25,7 @@ import org.pickly.service.member.controller.response.MemberProfileRes;
 import org.pickly.service.member.controller.response.MemberRegisterRes;
 import org.pickly.service.member.controller.response.MyProfileRes;
 import org.pickly.service.member.controller.response.SearchMemberResultRes;
+import org.pickly.service.member.service.dto.MemberProfileDTO;
 import org.pickly.service.member.service.dto.MemberRegisterDto;
 import org.pickly.service.member.service.interfaces.MemberService;
 import org.springframework.http.ResponseEntity;
@@ -153,6 +154,15 @@ public class MemberController {
     MemberRegisterDto memberRegisterDto = memberService.register(token);
     MemberRegisterRes response = memberMapper.toMemberRegisterResponse(memberRegisterDto);
     return ResponseEntity.ok(response);
+  }
+
+  @GetMapping("/id")
+  @Operation(summary = "Refresh token으로 유저 ID를 조회한다.")
+  public ResponseEntity<Long> getMemberId(
+      @RequestHeader("Authorization") String authorization) {
+    String token = RequestUtil.getAuthorizationToken(authorization);
+    MemberProfileDTO memberProfileDto = memberService.getMemberIdByToken(token);
+    return ResponseEntity.ok(memberProfileDto.getId());
   }
 
   @GetMapping("/{memberId}/search/{keyword}")

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/response/MemberRegisterRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/response/MemberRegisterRes.java
@@ -15,4 +15,5 @@ public class MemberRegisterRes {
   private String email;
   private String name;
   private String nickname;
+  private Long memberId;
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/repository/interfaces/MemberRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/repository/interfaces/MemberRepository.java
@@ -10,4 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   boolean existsByIdAndDeletedAtIsNull(Long id);
 
   Optional<Member> findByIdAndDeletedAtIsNull(Long id);
+
+  Optional<Member> findByEmail(String email);
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/dto/MemberRegisterDto.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/dto/MemberRegisterDto.java
@@ -14,4 +14,5 @@ public class MemberRegisterDto {
   private String name;
   private String nickname;
   private Password password;
+  private Long memberId;
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -75,6 +75,14 @@ public class MemberServiceImpl implements MemberService {
   }
 
   @Override
+  public MemberProfileDTO getMemberIdByToken(String token) {
+    FirebaseToken decodedToken = authTokenUtil.validateToken(token);
+    Member member = memberRepository.findByEmail(decodedToken.getEmail())
+        .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 유저입니다."));
+    return memberMapper.toMemberProfileDTO(member, false);
+  }
+
+  @Override
   @Transactional(readOnly = true)
   public List<SearchMemberResultResDTO> searchMemberByKeywords(String keyword, Long memberId,
       PageRequest pageRequest) {

--- a/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
@@ -34,4 +34,6 @@ public interface MemberService {
 
   List<SearchMemberResultResDTO> searchMemberByKeywords(String keyword, Long memberId,
       PageRequest pageRequest);
+
+  MemberProfileDTO getMemberIdByToken(String token);
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #176
- PR의 메인 내용

1. firebase 로그인 오류 수정
2. memberId return 로직 추가
3. refreshToken 기반 memberId 조회하는 API 추가

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] name이 없을 경우에 대한 처리 추가
- [x] memberId가 필요하므로 return 하도록 추가
- [x] refreshToken 기반으로 memberId 조회

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
