### PR TITLE
[fix]: 인자가 한 개인 생성자에 대한 역직렬화 오류 수정

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/notification/controller/request/NotifyStandardDayUpdateReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/controller/request/NotifyStandardDayUpdateReq.java
@@ -4,9 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 @Schema(description = "Notification standard day update request")
 public class NotifyStandardDayUpdateReq {
 

--- a/pickly-service/src/main/java/org/pickly/service/notification/controller/request/NotifyStandardDayUpdateReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/controller/request/NotifyStandardDayUpdateReq.java
@@ -1,19 +1,20 @@
 package org.pickly.service.notification.controller.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @Schema(description = "Notification standard day update request")
 public class NotifyStandardDayUpdateReq {
 
   @Schema(description = "북마크를 추가한 후 n일 이내 읽지 않았을 때 알림을 보낼 수 있도록 기준을 설정한다.", example = "3")
   @NotNull(message = "북마크 읽지 않음 알림 기준 일자를 입력해주세요")
+  @JsonProperty("notifyStandardDay")
   private Integer notifyStandardDay;
 
+  public NotifyStandardDayUpdateReq(@JsonProperty("notifyStandardDay") Integer notifyStandardDay) {
+    this.notifyStandardDay = notifyStandardDay;
+  }
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #179
- PR의 메인 내용

1. request body 역직렬화 오류 수정

<br>

## 🔨 작업 사항 (필수)

- 추가 또는 변경된 내용을 적어주세요.

- [x] @JsonProperty를 이용한 기본 생성자 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    

[참고 블로그](https://beaniejoy.tistory.com/76)
- 4. 인자가 한 개인 생성자만을 가진 형태