### PR TITLE
프로필 조회 API에서 북마크 수가 삭제된 것까지 카운트되는 이슈를 해결합니다.

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/bookmark/repository/interfaces/BookmarkRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/bookmark/repository/interfaces/BookmarkRepository.java
@@ -19,7 +19,7 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
   @Query("select b from Bookmark b join fetch b.category c where b.id = :id and b.deletedAt is null")
   Optional<Bookmark> findByIdWithCategory(@Param("id") Long id);
 
-  Long countByMemberId(Long memberId);
+  Long countByMemberIdAndDeletedAtNull(Long memberId);
 
   @Modifying(clearAutomatically = true)
   @Query("update Bookmark b set b.deletedAt = :deletedAt WHERE b.id IN :bookmarkIds")

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -104,7 +104,7 @@ public class MemberServiceImpl implements MemberService {
     Member member = findById(memberId);
     Long followersCount = friendRepository.countByFolloweeId(memberId);
     Long followeesCount = friendRepository.countByFollowerId(memberId);
-    Long bookmarksCount = bookmarkRepository.countByMemberId(memberId);
+    Long bookmarksCount = bookmarkRepository.countByMemberIdAndDeletedAtNull(memberId);
     return memberMapper.toMyProfileDTO(member, followersCount, followeesCount, bookmarksCount);
   }
 


### PR DESCRIPTION
## 📌 개요 (필수)

프로필 조회 API에서 북마크 수가 삭제된 것까지 카운트되는 이슈를 해결합니다.

Resolves #182.

<br>

## 🔨 작업 사항 (필수)

### AS-IS

```java
Long bookmarksCount = bookmarkRepository.countByMemberId(memberId);
```

### TO-BE

```java
Long bookmarksCount = bookmarkRepository.countByMemberIdAndDeletedAtNull(memberId);
```
