### PR TITLE
[Fix] 특정 유저 알림 내역 조회에 알림 생성시간 추가

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/notification/common/NotificationMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/common/NotificationMapper.java
@@ -1,11 +1,12 @@
 package org.pickly.service.notification.common;
 
-import org.pickly.service.notification.controller.request.NotifyStandardDayUpdateReq;
 import org.pickly.service.notification.controller.response.NotificationRes;
 import org.pickly.service.notification.entity.Notification;
 import org.pickly.service.notification.service.dto.NotificationDTO;
-import org.pickly.service.notification.service.dto.NotifyStandardDayUpdateDTO;
 import org.springframework.stereotype.Component;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 @Component
 public class NotificationMapper {
@@ -17,16 +18,20 @@ public class NotificationMapper {
         .content(dto.getContent())
         .bookmarkId(dto.getBookmarkId())
         .isChecked(dto.getIsChecked())
+        .createdAt(dto.getCreatedAt())
         .build();
   }
 
   public NotificationDTO toDto(Notification entity) {
+    ZonedDateTime utcDateTime = entity.getCreatedAt().atZone(ZoneOffset.UTC);
+    long unixTimestamp = utcDateTime.toEpochSecond();
     return NotificationDTO.builder()
         .id(entity.getId())
         .title(entity.getTitle())
         .content(entity.getContent())
         .bookmarkId(entity.getBookmarkId())
         .isChecked(entity.isChecked())
+        .createdAt(unixTimestamp)
         .build();
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/notification/controller/response/NotificationRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/controller/response/NotificationRes.java
@@ -23,4 +23,7 @@ public class NotificationRes {
   @Schema(description = "Is member read this notification?", example = "true")
   private Boolean isChecked;
 
+  @Schema(description = "notification create time : utc timestamp", example = "12131411")
+  private long createdAt;
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/notification/service/dto/NotificationDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/service/dto/NotificationDTO.java
@@ -1,6 +1,5 @@
 package org.pickly.service.notification.service.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -13,5 +12,6 @@ public class NotificationDTO {
   private String content;
   private Long bookmarkId;
   private Boolean isChecked;
+  private long createdAt;
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/notification/service/impl/NotificationServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/service/impl/NotificationServiceImpl.java
@@ -1,7 +1,5 @@
 package org.pickly.service.notification.service.impl;
 
-import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.pickly.common.error.exception.EntityNotFoundException;
 import org.pickly.service.member.service.interfaces.MemberService;
@@ -12,6 +10,8 @@ import org.pickly.service.notification.service.dto.NotificationDTO;
 import org.pickly.service.notification.service.interfaces.NotificationService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -27,7 +27,7 @@ public class NotificationServiceImpl implements NotificationService {
     memberService.existsById(memberId);
     List<Notification> notifications = notificationRepository.findAllByMemberIdAndDeletedAtNull(
         memberId);
-    return notifications.stream().map(notificationMapper::toDto).collect(Collectors.toList());
+    return notifications.stream().map(notificationMapper::toDto).toList();
   }
 
   @Override


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #185 

<br>

## 🔨 작업 사항 (필수)

- 특정 유저 알림 내역 조회 API res에 unix timestamp createdAt 추가 (UTC 기준)

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
