### PR TITLE
[Fix] 팔로워, 팔로잉 유저 조회, 유저 검색 API에 유저 이모지 정보 추가

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/friend/common/FriendMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/friend/common/FriendMapper.java
@@ -31,11 +31,12 @@ public class FriendMapper {
         .memberId(dto.getMemberId())
         .loginId(dto.getLoginId())
         .isFollowing(dto.getIsFollowing())
+        .emoji(dto.getEmoji())
         .build();
   }
 
   public FollowingRes toFollowingRes(FollowingResDTO dto) {
-    return new FollowingRes(dto.getMemberId(), dto.getLoginId());
+    return new FollowingRes(dto.getMemberId(), dto.getLoginId(), dto.getEmoji());
   }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/friend/controller/response/FollowerRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/friend/controller/response/FollowerRes.java
@@ -13,4 +13,6 @@ public class FollowerRes {
 
   private Boolean isFollowing;
 
+  private String emoji;
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/friend/controller/response/FollowingRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/friend/controller/response/FollowingRes.java
@@ -11,4 +11,6 @@ public class FollowingRes {
 
   private String loginId;
 
+  private String emoji;
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/friend/service/dto/FollowerResDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/friend/service/dto/FollowerResDTO.java
@@ -20,11 +20,14 @@ public class FollowerResDTO {
 
   private Boolean isFollowing;
 
+  private String emoji;
+
   @QueryProjection
   public FollowerResDTO(Long followeeId, Friend follower, Member followerInfo) {
     this.memberId = followerInfo.getId();
     this.loginId = followerInfo.getUsername();
     this.isFollowing = (follower == null) ? false : followeeId.equals(follower.getFollower().getId());
+    this.emoji = followerInfo.getProfileEmoji();
   }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/friend/service/dto/FollowingResDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/friend/service/dto/FollowingResDTO.java
@@ -17,10 +17,13 @@ public class FollowingResDTO {
 
   private String loginId;
 
+  private String emoji;
+
   @QueryProjection
   public FollowingResDTO(Member followerInfo) {
     this.memberId = followerInfo.getId();
     this.loginId = followerInfo.getUsername();
+    this.emoji = followerInfo.getProfileEmoji();
   }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
@@ -134,7 +134,7 @@ public class MemberMapper {
 
   public SearchMemberResultRes toSearchMemberResultRes(SearchMemberResultResDTO dto) {
     return new SearchMemberResultRes(
-        dto.getMemberId(), dto.getNickname(), dto.getProfileImageUrl(),
+        dto.getMemberId(), dto.getNickname(),
         dto.getIsFollowing(), dto.getEmoji());
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
@@ -133,8 +133,9 @@ public class MemberMapper {
   }
 
   public SearchMemberResultRes toSearchMemberResultRes(SearchMemberResultResDTO dto) {
-    return new SearchMemberResultRes(dto.getMemberId(), dto.getNickname(), dto.getProfileImageUrl(),
-        dto.getIsFollowing());
+    return new SearchMemberResultRes(
+        dto.getMemberId(), dto.getNickname(), dto.getProfileImageUrl(),
+        dto.getIsFollowing(), dto.getEmoji());
   }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/response/SearchMemberResultRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/response/SearchMemberResultRes.java
@@ -13,4 +13,6 @@ public class SearchMemberResultRes {
   private String nickname;
   private String profileImageUrl;
   private Boolean isFollowing;
+  private String emoji;
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/response/SearchMemberResultRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/response/SearchMemberResultRes.java
@@ -11,7 +11,6 @@ public class SearchMemberResultRes {
 
   private Long memberId;
   private String nickname;
-  private String profileImageUrl;
   private Boolean isFollowing;
   private String emoji;
 

--- a/pickly-service/src/main/java/org/pickly/service/member/repository/impl/MemberQueryRepositoryImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/repository/impl/MemberQueryRepositoryImpl.java
@@ -1,16 +1,17 @@
 package org.pickly.service.member.repository.impl;
 
-import static org.pickly.service.member.entity.QMember.member;
-
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.pickly.service.common.utils.page.PageRequest;
 import org.pickly.service.member.repository.interfaces.MemberQueryRepository;
 import org.pickly.service.member.service.dto.SearchMemberResultResDTO;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static org.pickly.service.member.entity.QMember.member;
 
 @Repository
 @RequiredArgsConstructor

--- a/pickly-service/src/main/java/org/pickly/service/member/service/dto/SearchMemberResultResDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/dto/SearchMemberResultResDTO.java
@@ -11,11 +11,13 @@ public class SearchMemberResultResDTO {
   private String nickname;
   private String profileImageUrl;
   private Boolean isFollowing;
+  private String emoji;
 
-  public SearchMemberResultResDTO(Long memberId, String nickname, String profileImageUrl) {
+  public SearchMemberResultResDTO(Long memberId, String nickname, String profileImageUrl, String emoji) {
     this.memberId = memberId;
     this.nickname = nickname;
     this.profileImageUrl = profileImageUrl;
+    this.emoji = emoji;
   }
 
   public void setFollowingFlag(Boolean isFollowing) {

--- a/pickly-service/src/main/java/org/pickly/service/member/service/dto/SearchMemberResultResDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/dto/SearchMemberResultResDTO.java
@@ -9,14 +9,12 @@ public class SearchMemberResultResDTO {
 
   private Long memberId;
   private String nickname;
-  private String profileImageUrl;
   private Boolean isFollowing;
   private String emoji;
 
-  public SearchMemberResultResDTO(Long memberId, String nickname, String profileImageUrl, String emoji) {
+  public SearchMemberResultResDTO(Long memberId, String nickname, String emoji) {
     this.memberId = memberId;
     this.nickname = nickname;
-    this.profileImageUrl = profileImageUrl;
     this.emoji = emoji;
   }
 


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #188 

<br>

## 🔨 작업 사항 (필수)

- 팔로워 조회 API, 팔로잉 조회 API, 유저 검색 API 필드에 emoji 필드 추가
- 유저 검색 API res 필드에서 profile image url 필드 삭제

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
