### PR TITLE
[bug] 차단 유저 & 북마크 조회시, 포멧양식과 중복 조회가 발생합니다.

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/block/common/BlockMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/block/common/BlockMapper.java
@@ -3,9 +3,7 @@ package org.pickly.service.block.common;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.pickly.service.block.controller.response.BlockBookmarkRes;
-import org.pickly.service.block.controller.response.BlockBookmarkRes.BlockBookmark;
 import org.pickly.service.block.controller.response.BlockMemberRes;
-import org.pickly.service.block.controller.response.BlockMemberRes.BlockMember;
 import org.pickly.service.block.service.dto.BlockBookmarkDTO;
 import org.pickly.service.block.service.dto.BlockMemberDTO;
 import org.springframework.stereotype.Component;
@@ -13,21 +11,14 @@ import org.springframework.stereotype.Component;
 @Component
 public class BlockMapper {
 
-  public static BlockMemberRes toMember(List<BlockMemberDTO> blockMemberDTO) {
-    List<BlockMember> blockMemberList = blockMemberDTO.stream().map(blockMember ->
-            BlockMember.of(blockMember.getId(), blockMember.getNickname(),
-                blockMember.getProfileEmoji()))
-        .collect(Collectors.toList());
-
-    return BlockMemberRes.of(blockMemberList);
+  public static BlockMemberRes toMember(BlockMemberDTO blockMemberDTO) {
+    return new BlockMemberRes(blockMemberDTO.getId(), blockMemberDTO.getNickname(),
+        blockMemberDTO.getProfileEmoji());
   }
 
-  public static BlockBookmarkRes toBookmark(List<BlockBookmarkDTO> blockBookmarkDTO) {
-    List<BlockBookmark> blockBookmarkList = blockBookmarkDTO.stream().map(blockBookmark ->
-            BlockBookmark.of(blockBookmark.getId(), blockBookmark.getTitle(),
-                blockBookmark.getPreviewImageUrl()))
-        .collect(Collectors.toList());
+  public static BlockBookmarkRes toBookmark(BlockBookmarkDTO blockBookmarkDTO) {
 
-    return BlockBookmarkRes.of(blockBookmarkList);
+    return new BlockBookmarkRes(blockBookmarkDTO.getId(), blockBookmarkDTO.getTitle(),
+        blockBookmarkDTO.getPreviewImageUrl());
   }
 }

--- a/pickly-service/src/main/java/org/pickly/service/block/controller/BlockController.java
+++ b/pickly-service/src/main/java/org/pickly/service/block/controller/BlockController.java
@@ -80,9 +80,9 @@ public class BlockController {
 
       @Parameter(name = "cursorId", description = "마지막 끝의 Id", example = "1") final @RequestParam(required = false) String cursorId,
 
-      @Parameter(name = "size", description = "페이지 사이즈", example = "1") final @RequestParam(defaultValue = "15") Integer size
+      @Parameter(name = "pageSize", description = "페이지 사이즈", example = "1") final @RequestParam(defaultValue = "15") Integer pageSize
   ) {
-    PageRequest pageRequest = new PageRequest(cursorId, size);
+    PageRequest pageRequest = new PageRequest(cursorId, pageSize);
     List<BlockMemberRes> blockedMembers = blockService.getBlockedMembers(blockerId, pageRequest)
         .stream()
         .map(BlockMapper::toMember)

--- a/pickly-service/src/main/java/org/pickly/service/block/controller/BlockController.java
+++ b/pickly-service/src/main/java/org/pickly/service/block/controller/BlockController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.pickly.service.block.common.BlockMapper;
@@ -14,6 +15,7 @@ import org.pickly.service.block.service.BlockService;
 import org.pickly.service.block.service.dto.BlockBookmarkDTO;
 import org.pickly.service.block.service.dto.BlockMemberDTO;
 import org.pickly.service.common.utils.page.PageRequest;
+import org.pickly.service.common.utils.page.PageResponse;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -71,19 +73,28 @@ public class BlockController {
 
   @GetMapping("/member/blocks/{blockerId}")
   @Operation(summary = "차단한 유저 목록을 조회한다.")
-  public BlockMemberRes getBlockedMembers(
+  public PageResponse<BlockMemberRes> getBlockedMembers(
       @Parameter(name = "blockerId", description = "유저 차단조회를 위한 대상 ID 값", example = "1", required = true)
       @Positive(message = "유저 ID는 양수입니다.")
       @PathVariable final Long blockerId,
 
-      @Parameter(name = "cursorId", description = "마지막 끝의 Id", example = "1", required = true) final @RequestParam(required = false) String cursorId,
+      @Parameter(name = "cursorId", description = "마지막 끝의 Id", example = "1") final @RequestParam(required = false) String cursorId,
 
-      @Parameter(name = "size", description = "페이지 사이즈", example = "1", required = true) final @RequestParam(defaultValue = "15") Integer size
+      @Parameter(name = "size", description = "페이지 사이즈", example = "1") final @RequestParam(defaultValue = "15") Integer size
   ) {
     PageRequest pageRequest = new PageRequest(cursorId, size);
-    List<BlockMemberDTO> blockedMembers = blockService.getBlockedMembers(blockerId, pageRequest);
+    List<BlockMemberRes> blockedMembers = blockService.getBlockedMembers(blockerId, pageRequest)
+        .stream()
+        .map(BlockMapper::toMember)
+        .collect(Collectors.toList());
 
-    return BlockMapper.toMember(blockedMembers);
+    PageResponse<BlockMemberRes> response = new PageResponse<>(
+        blockedMembers.size(),
+        pageRequest.getPageSize(), blockedMembers);
+
+    response.removeElement(pageRequest.getPageSize());
+
+    return response;
   }
 
 
@@ -118,16 +129,26 @@ public class BlockController {
 
   @GetMapping("/bookmark/blocks/{blockerId}")
   @Operation(summary = "차단된 북마크 목록을 조회한다.")
-  public BlockBookmarkRes getBlockedBookmarks(
+  public PageResponse<BlockBookmarkRes> getBlockedBookmarks(
       @Parameter(name = "blockerId", description = "북마크 차단조회를 위한 대상 ID 값", example = "1", required = true)
       @Positive(message = "유저 ID는 양수입니다.") @PathVariable final Long blockerId,
 
-      @Parameter(name = "cursorId", description = "페이지 번호", example = "1", required = true) final @RequestParam(required = false) String cursorId,
-      @Parameter(name = "pageSize", description = "페이지 사이즈", example = "1", required = true) final @RequestParam(defaultValue = "15") Integer pageSize
+      @Parameter(name = "cursorId", description = "마지막 member의 Id", example = "1") final @RequestParam(required = false) String cursorId,
+      @Parameter(name = "pageSize", description = "페이지 사이즈", example = "1") final @RequestParam(defaultValue = "15") Integer pageSize
   ) {
     PageRequest pageRequest = new PageRequest(cursorId, pageSize);
-    List<BlockBookmarkDTO> blockedBookmarks = blockService.getBlockedBookmarks(blockerId, pageRequest);
 
-    return BlockMapper.toBookmark(blockedBookmarks);
+    List<BlockBookmarkRes> blockedBookmarks = blockService.getBlockedBookmarks(blockerId, pageRequest)
+        .stream()
+        .map(BlockMapper::toBookmark)
+        .collect(Collectors.toList());
+
+    PageResponse<BlockBookmarkRes> response = new PageResponse<>(
+        blockedBookmarks.size(),
+        pageRequest.getPageSize(), blockedBookmarks);
+
+    response.removeElement(pageRequest.getPageSize());
+
+    return response;
   }
 }

--- a/pickly-service/src/main/java/org/pickly/service/block/controller/response/BlockBookmarkRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/block/controller/response/BlockBookmarkRes.java
@@ -1,6 +1,5 @@
 package org.pickly.service.block.controller.response;
 
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,24 +9,11 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class BlockBookmarkRes {
 
-  private List<BlockBookmark> data;
+  private Long id;
+  private String title;
+  private String previewImageUrl;
 
-  public static BlockBookmarkRes of(List<BlockBookmark> blockBookmarks) {
-    return new BlockBookmarkRes(blockBookmarks);
+  public static BlockBookmarkRes of(Long id, String title, String previewImageUrl) {
+    return new BlockBookmarkRes(id, title, previewImageUrl);
   }
-
-  @Getter
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class BlockBookmark {
-
-    private Long id;
-    private String title;
-    private String previewImageUrl;
-
-    public static BlockBookmark of(Long id, String title, String previewImageUrl) {
-      return new BlockBookmark(id, title, previewImageUrl);
-    }
-  }
-
 }

--- a/pickly-service/src/main/java/org/pickly/service/block/controller/response/BlockMemberRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/block/controller/response/BlockMemberRes.java
@@ -1,6 +1,5 @@
 package org.pickly.service.block.controller.response;
 
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,24 +9,8 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class BlockMemberRes {
 
-  private List<BlockMember> data;
-
-  public static BlockMemberRes of(List<BlockMember> blockMembers) {
-    return new BlockMemberRes(blockMembers);
-  }
-
-  @Getter
-  @NoArgsConstructor
-  @AllArgsConstructor
-  public static class BlockMember {
-
-    private Long id;
-    private String nickname;
-    private String profileEmoji;
-
-    public static BlockMember of(Long id, String name, String profileEmoji) {
-      return new BlockMember(id, name, profileEmoji);
-    }
-  }
+  private Long id;
+  private String nickname;
+  private String profileEmoji;
 
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #208 
- PR의 메인 내용
- 차단 유저 & 북마크 조회시 발생하던 중복 조회를 수정합니다. 
- 다른 API 양식과 맞게, Response 포멧을 수정합니다. 
- Swagger 파라미터에서 Required = true 로 설정되어있던, 항목을 false로 변경합니다. 

<br>

