### PR TITLE
[feat] 로그인 API에 fcm 토큰 upsert 로직을 추가한다

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/ServiceApplication.java
+++ b/pickly-service/src/main/java/org/pickly/service/ServiceApplication.java
@@ -8,7 +8,9 @@ import org.springframework.boot.context.ApplicationPidFileWriter;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class ServiceApplication extends SpringBootServletInitializer {

--- a/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/common/MemberMapper.java
@@ -113,7 +113,7 @@ public class MemberMapper {
     );
   }
 
-  public Member tokenToMember(FirebaseToken token) {
+  public Member tokenToMember(FirebaseToken token, String fcmToken) {
     //TODO: password nullable한 값으로 변경?
     Password password = new Password("test123");
 
@@ -124,6 +124,7 @@ public class MemberMapper {
         .nickname("")
         .isHardMode(false)
         .password(password)
+        .fcmToken(fcmToken)
         .build();
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -1,7 +1,5 @@
 package org.pickly.service.member.controller;
 
-import static org.springframework.http.HttpStatus.NO_CONTENT;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -11,7 +9,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.pickly.service.common.utils.base.RequestUtil;
 import org.pickly.service.common.utils.page.PageRequest;
@@ -19,28 +16,17 @@ import org.pickly.service.common.utils.page.PageResponse;
 import org.pickly.service.member.common.MemberMapper;
 import org.pickly.service.member.controller.request.MemberProfileUpdateReq;
 import org.pickly.service.member.controller.request.MemberStatusReq;
-import org.pickly.service.member.controller.response.HardModeRes;
-import org.pickly.service.member.controller.response.MemberModeRes;
-import org.pickly.service.member.controller.response.MemberProfileRes;
-import org.pickly.service.member.controller.response.MemberRegisterRes;
-import org.pickly.service.member.controller.response.MyProfileRes;
-import org.pickly.service.member.controller.response.SearchMemberResultRes;
+import org.pickly.service.member.controller.response.*;
 import org.pickly.service.member.service.dto.MemberProfileDTO;
 import org.pickly.service.member.service.dto.MemberRegisterDto;
 import org.pickly.service.member.service.interfaces.MemberService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 @RestController
 @RequiredArgsConstructor
@@ -149,7 +135,8 @@ public class MemberController {
   @PostMapping("/register")
   @Operation(summary = "회원가입")
   public ResponseEntity<MemberRegisterRes> register(
-      @RequestHeader("Authorization") String authorization) {
+      @RequestHeader("Authorization") String authorization
+  ) {
     String token = RequestUtil.getAuthorizationToken(authorization);
     MemberRegisterDto memberRegisterDto = memberService.register(token);
     MemberRegisterRes response = memberMapper.toMemberRegisterResponse(memberRegisterDto);

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -14,6 +14,7 @@ import org.pickly.service.common.utils.base.RequestUtil;
 import org.pickly.service.common.utils.page.PageRequest;
 import org.pickly.service.common.utils.page.PageResponse;
 import org.pickly.service.member.common.MemberMapper;
+import org.pickly.service.member.controller.request.FcmTokenReq;
 import org.pickly.service.member.controller.request.MemberProfileUpdateReq;
 import org.pickly.service.member.controller.request.MemberStatusReq;
 import org.pickly.service.member.controller.response.*;
@@ -135,10 +136,11 @@ public class MemberController {
   @PostMapping("/register")
   @Operation(summary = "회원가입")
   public ResponseEntity<MemberRegisterRes> register(
-      @RequestHeader("Authorization") String authorization
+      @RequestHeader("Authorization") String authorization,
+      @RequestBody @Valid FcmTokenReq tokenReq
   ) {
     String token = RequestUtil.getAuthorizationToken(authorization);
-    MemberRegisterDto memberRegisterDto = memberService.register(token);
+    MemberRegisterDto memberRegisterDto = memberService.register(token, tokenReq.getFcmToken());
     MemberRegisterRes response = memberMapper.toMemberRegisterResponse(memberRegisterDto);
     return ResponseEntity.ok(response);
   }

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/request/FcmTokenReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/request/FcmTokenReq.java
@@ -1,0 +1,19 @@
+package org.pickly.service.member.controller.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Schema(description = "Member Fcm token")
+public class FcmTokenReq {
+
+  @NotBlank(message = "유저의 FCM 토큰을 입력해주세요.")
+  @Schema(description = "fcm token", example = "jdafjlajl1213d!!3d~1")
+  private String fcmToken;
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/member/repository/interfaces/MemberRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/repository/interfaces/MemberRepository.java
@@ -1,15 +1,24 @@
 package org.pickly.service.member.repository.interfaces;
 
-import java.util.Optional;
 import org.pickly.service.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
 
   boolean existsByIdAndDeletedAtIsNull(Long id);
 
+  boolean existsByEmailAndDeletedAtIsNull(String email);
+
+  boolean existsByNicknameAndDeletedAtIsNull(String nickname);
+
+  boolean existsByUsernameAndDeletedAtIsNull(String username);
+
   Optional<Member> findByIdAndDeletedAtIsNull(Long id);
+
+  Optional<Member> findByEmailAndDeletedAtIsNull(String email);
 
   Optional<Member> findByEmail(String email);
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
@@ -25,7 +25,7 @@ public interface MemberService {
 
   HardModeDTO setHardMode(Long memberId, MemberStatusDTO request);
 
-  MemberRegisterDto register(String token);
+  MemberRegisterDto register(String token, String fcmToken);
 
   Map<Long, String> findTokenByIds(List<Long> memberIds);
 

--- a/pickly-service/src/main/java/org/pickly/service/notification/scheduler/NotificationScheduler.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/scheduler/NotificationScheduler.java
@@ -29,20 +29,16 @@ public class NotificationScheduler {
 
   @Scheduled(cron = "0 0/15 * * * *")
   public void makeNormalNotification() {
-
     Map<Member, List<Bookmark>> unreadBookmarks = bookmarkService.findAllUnreadBookmark();
     List<Notification> notifications = notificationService.makeNormals(unreadBookmarks);
     notificationService.saveAll(notifications);
-
   }
 
   @Scheduled(cron = "0 0/30 * * * *")
   public void sendNormalNotification() {
-
     LocalDateTime now = LocalDateTime.now(ZoneId.of(KST));
     List<Notification> notifications = notificationService.getNotificationsToSend(now);
     notificationSender.sendMessage(notifications);
-
   }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/notification/service/impl/NotificationServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/notification/service/impl/NotificationServiceImpl.java
@@ -1,6 +1,7 @@
 package org.pickly.service.notification.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.pickly.common.error.exception.EntityNotFoundException;
 import org.pickly.service.bookmark.entity.Bookmark;
 import org.pickly.service.member.entity.Member;
@@ -26,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -54,7 +56,6 @@ public class NotificationServiceImpl implements NotificationService {
 
     List<NotificationTemplate> templates = notificationTemplateService.findAllByNotificationType(NotificationType.NORMAL);
     LocalDateTime now = LocalDateTime.now(ZoneId.of(KST));
-
     for (Map.Entry<Member, List<Bookmark>> entry : unreadBookmarks.entrySet()) {
       Long memberId = entry.getKey().getId();
       NotificationStandard standard = notificationStandardService.findByMemberId(memberId);
@@ -115,11 +116,13 @@ public class NotificationServiceImpl implements NotificationService {
   }
 
   @Override
+  @Transactional
   public void saveAll(List<Notification> notifications) {
     notificationJdbcRepository.saveAll(notifications);
   }
 
   @Override
+  @Transactional
   public void updateAllToSend(List<Notification> notifications) {
     List<Long> ids = notifications.stream().map(Notification::getId).toList();
     notificationRepository.updateAllToSend(ids);

--- a/pickly-service/src/main/resources/application.yml
+++ b/pickly-service/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   # 실행할 프로필 정보
   profiles:
-    active: dev
+    active: local
   # multipart 이용 시 파일/리퀘스트 사이즈 제한
   servlet:
     multipart:

--- a/pickly-service/src/main/resources/application.yml
+++ b/pickly-service/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
   # 실행할 프로필 정보
   profiles:
-    active: local
+    active: dev
   # multipart 이용 시 파일/리퀘스트 사이즈 제한
   servlet:
     multipart:


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #211 

<br>

## 🔨 작업 사항 (필수)

- register API 수정 : 이미 존재하는 계정이라면 정보만 리턴하게 (로그인) 수정 => 로그인 풀리는 상황 방지
- register 과정에 fcmToken upsert 추가
  - 이미 존재하는 계정이라면 fcmToken update
  - 신규 계정이라면 fcmToken insert

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
