### PR TITLE
[feat] 유저 nickname 최대 길이 변경

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/member/controller/request/MemberProfileUpdateReq.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/request/MemberProfileUpdateReq.java
@@ -17,7 +17,7 @@ public class MemberProfileUpdateReq {
   private String name;
 
   @NotBlank(message = "사용자 닉네임을 입력해주세요.")
-  @Length(max = 20, message = "사용자 닉네임은 20글자 이하로 입력해야 합니다.")
+  @Length(max = 7, message = "사용자 닉네임은 7글자 이하로 입력해야 합니다.")
   @Schema(description = "member nickname", example = "johndoe")
   private String nickname;
 


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #216 

<br>

## 🔨 작업 사항 (필수)

- member 프로필 수정시 nickname 길이 제한 정책 변경 : 20 -> 7글자

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
