### PR TITLE
[feat] 크롬 익스텐션 대응 - 인증코드 발급 기능

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,7 +6,7 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-gradle
 
 # github repository Actions 페이지에 나타날 이름 
-name: Pickly Backend CI / CD 
+name: Pickly Backend CI / CD
 
 # develop 브렌치에 Push되었을 경우 Workflow Trigger을 실행한다. 
 on:
@@ -49,6 +49,12 @@ jobs:
         run: |
           cd ./pickly-service/src/main/resources
           echo "${{ secrets.SERVICE_FIREBASE_CONFIG }}" > ./firebase.json
+        shell: bash
+
+      - name: Create extension encrypt key
+        run: |
+          cd ./pickly-service/src/main/resources
+          echo "${{ secrets.ET_KEY }}" > ./extension.json
         shell: bash
 
       - name: Build Gradle wrapper

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,12 @@ jobs:
           echo "${{ secrets.FIREBASE_CONFIG }}" > ./firebase.json
         shell: bash
 
+      - name: Create extension encrypt key
+        run: |
+          cd ./pickly-service/src/main/resources
+          echo "${{ secrets.ET_KEY }}" > ./extension.json
+        shell: bash
+
       - name: Cache Gradle
         uses: actions/cache@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ data/
 application.pid
 .env-dev
 firebase.json
+extension.json

--- a/pickly-service/src/main/java/org/pickly/service/common/config/CacheConfig.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/config/CacheConfig.java
@@ -1,0 +1,36 @@
+package org.pickly.service.common.config;
+
+import org.pickly.service.common.utils.cache.ExpireConcurrentMapCache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.Set;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+  private static final String AUTHENTICATE = "authenticate";
+
+  @Bean
+  public CacheManager cacheManager() {
+    SimpleCacheManager cacheManager = new SimpleCacheManager();
+    cacheManager.setCaches(Set.of(
+        new ExpireConcurrentMapCache(AUTHENTICATE, 5L)
+    ));
+    return cacheManager;
+  }
+
+  @Scheduled(cron = "0 0 0 * * *")
+  private void evict() {
+    ExpireConcurrentMapCache cache = (ExpireConcurrentMapCache) cacheManager().getCache(AUTHENTICATE);
+    if (cache != null) {
+      cache.evictAllExpired();
+    }
+  }
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/common/config/CacheConfig.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/config/CacheConfig.java
@@ -20,7 +20,7 @@ public class CacheConfig {
   public CacheManager cacheManager() {
     SimpleCacheManager cacheManager = new SimpleCacheManager();
     cacheManager.setCaches(Set.of(
-        new ExpireConcurrentMapCache(AUTHENTICATE, 5L)
+        new ExpireConcurrentMapCache(AUTHENTICATE, 300L)
     ));
     return cacheManager;
   }

--- a/pickly-service/src/main/java/org/pickly/service/common/config/CacheConfig.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/config/CacheConfig.java
@@ -14,7 +14,7 @@ import java.util.Set;
 @Configuration
 public class CacheConfig {
 
-  private static final String AUTHENTICATE = "authenticate";
+  public static final String AUTHENTICATE = "authenticate";
 
   @Bean
   public CacheManager cacheManager() {

--- a/pickly-service/src/main/java/org/pickly/service/common/utils/cache/ExpireConcurrentMapCache.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/utils/cache/ExpireConcurrentMapCache.java
@@ -1,0 +1,52 @@
+package org.pickly.service.common.utils.cache;
+
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class ExpireConcurrentMapCache extends ConcurrentMapCache {
+
+  private final Map<Object, LocalDateTime> expires = new ConcurrentHashMap<>();
+  private final Long expireAfter;
+
+  public ExpireConcurrentMapCache(final String name, final Long expireAfter) {
+    super(name);
+    this.expireAfter = expireAfter;
+  }
+
+  @Override
+  protected Object lookup(final Object key) {
+    LocalDateTime expiredDate = expires.get(key);
+    if (Objects.isNull(expiredDate) || LocalDateTime.now().isBefore(expiredDate)) {
+      return super.lookup(key);
+    }
+    expires.remove(key);
+    super.evict(key);
+    return null;
+  }
+
+  @Override
+  public void put(final Object key, final Object value) {
+    LocalDateTime expiredAt =
+        (expireAfter == null) ? null : LocalDateTime.now().plusSeconds(expireAfter);
+    expires.put(key, expiredAt);
+    super.put(key, value);
+  }
+
+  public void evictAllExpired() {
+    ConcurrentMap<Object, Object> nativeCache = getNativeCache();
+    nativeCache.keySet()
+        .stream()
+        .filter(key -> !isCacheValid(expires.get(key)))
+        .forEach(super::evict);
+  }
+
+  private boolean isCacheValid(LocalDateTime expiredAt) {
+    return LocalDateTime.now().isBefore(expiredAt);
+  }
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/common/utils/encrypt/EncryptService.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/utils/encrypt/EncryptService.java
@@ -1,0 +1,35 @@
+package org.pickly.service.common.utils.encrypt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class EncryptService {
+
+  private final ExtensionKey extensionKey;
+
+  private static final String JSON_TYPE_SUFFIX = ".json";
+
+  @Autowired
+  public EncryptService(ApplicationContext context) {
+    this.extensionKey = context.getBean(ExtensionKey.class);
+    ObjectMapper objectMapper = new ObjectMapper();
+    try {
+      ClassPathResource resource = new ClassPathResource("extension" + JSON_TYPE_SUFFIX);
+      ExtensionKey key = objectMapper.readValue(resource.getInputStream(), ExtensionKey.class);
+      extensionKey.setKey(key.getKey());
+    } catch (Exception e) {
+      log.warn("can not read extension key");
+    }
+  }
+
+  public ExtensionKey getKey() {
+    return extensionKey;
+  }
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/common/utils/encrypt/ExtensionKey.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/utils/encrypt/ExtensionKey.java
@@ -1,0 +1,42 @@
+package org.pickly.service.common.utils.encrypt;
+
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+@Component
+public class ExtensionKey {
+
+  private String key;
+  private static final String ALGORITHM = "AES";
+
+  public String getKey() {
+    return key;
+  }
+
+  public void setKey(String key) {
+    this.key = key;
+  }
+
+  private SecretKey generateKey() {
+    byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+    return new SecretKeySpec(keyBytes, ALGORITHM);
+  }
+
+  public String encrypt(Long value) {
+    try {
+      Cipher cipher = Cipher.getInstance(ALGORITHM);
+      cipher.init(Cipher.ENCRYPT_MODE, generateKey());
+      byte[] encrypted = cipher.doFinal(Long.toString(value).getBytes(StandardCharsets.UTF_8));
+      return Base64.getEncoder().encodeToString(encrypted);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    return null;
+  }
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -230,7 +230,7 @@ public class MemberController {
       @ApiResponse(responseCode = "200", description = "성공"),
       @ApiResponse(responseCode = "404", description = "잘못된 인증 코드"),
   })
-  public Long checkMemberAuthenticationCode(
+  public String checkMemberAuthenticationCode(
       @Parameter(name = "code", description = "발급 받은 인증 코드 값", example = "2319", required = true)
       @NotBlank(message = "인증 코드는 필수 값입니다.") @RequestParam final String code
   ) {

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -205,4 +205,21 @@ public class MemberController {
 
     return response;
   }
+
+  @PostMapping("/{memberId}/authentication-code")
+  @Operation(
+      summary = "크롬 익스텐션 대응 : 멤버 인증코드를 발급한다.",
+      description = "웹 로그인을 할 때 사용할 본인 인증용 인증코드를 발급한다. (만료 기한 = 5분)")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 ID"),
+  })
+  public String makeMemberAuthenticationCode(
+      @Parameter(name = "memberId", description = "유저 ID 값", example = "1", required = true)
+      @Positive(message = "유저 ID는 양수입니다.") @PathVariable final Long memberId
+  ) {
+    return memberService.makeMemberAuthenticationCode(memberId);
+  }
+
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.pickly.service.common.utils.base.RequestUtil;
@@ -221,5 +222,19 @@ public class MemberController {
     return memberService.makeMemberAuthenticationCode(memberId);
   }
 
+  @DeleteMapping("/authentication-code")
+  @Operation(
+      summary = "크롬 익스텐션 대응 : 멤버 인증 코드를 확인한다.",
+      description = "인증 코드를 제출하고, 맵핑된 멤버 ID를 받는다. 멤버 ID는 암호화한다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "성공"),
+      @ApiResponse(responseCode = "404", description = "잘못된 인증 코드"),
+  })
+  public Long checkMemberAuthenticationCode(
+      @Parameter(name = "code", description = "발급 받은 인증 코드 값", example = "2319", required = true)
+      @NotBlank(message = "인증 코드는 필수 값입니다.") @RequestParam final String code
+  ) {
+    return memberService.checkMemberAuthenticationCode(code);
+  }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/exception/MemberErrorCode.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/exception/MemberErrorCode.java
@@ -9,6 +9,7 @@ public enum MemberErrorCode implements ErrorCode {
 
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "M001", "존재하지 않는 유저 정보입니다."),
   NICKNAME_DUPLICATE_EXCEPTION(HttpStatus.CONFLICT, "M002", "이미 존재하는 닉네임입니다."),
+  CODE_NOT_FOUND(HttpStatus.NOT_FOUND, "M003", "존재하지 않는 코드 입니다.")
   ;
 
   private final HttpStatus status;

--- a/pickly-service/src/main/java/org/pickly/service/member/exception/MemberException.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/exception/MemberException.java
@@ -20,4 +20,10 @@ public abstract class MemberException extends BusinessException {
     }
   }
 
+  public static class CodeNotFoundException extends MemberException {
+    public CodeNotFoundException() {
+      super(MemberErrorCode.CODE_NOT_FOUND);
+    }
+  }
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/impl/MemberServiceImpl.java
@@ -6,6 +6,8 @@ import org.pickly.service.block.repository.interfaces.BlockRepository;
 import org.pickly.service.bookmark.repository.interfaces.BookmarkRepository;
 import org.pickly.service.common.config.CacheConfig;
 import org.pickly.service.common.utils.base.AuthTokenUtil;
+import org.pickly.service.common.utils.encrypt.EncryptService;
+import org.pickly.service.common.utils.encrypt.ExtensionKey;
 import org.pickly.service.common.utils.page.PageRequest;
 import org.pickly.service.friend.repository.interfaces.FriendRepository;
 import org.pickly.service.member.common.MemberMapper;
@@ -43,6 +45,7 @@ public class MemberServiceImpl implements MemberService {
   private final NotificationStandardRepository notificationStandardRepository;
   private final AuthTokenUtil authTokenUtil;
   private final CacheManager cacheManager;
+  private final EncryptService encryptService;
 
   @Transactional(readOnly = true)
   public NotificationStandard findNotificationStandardByMemberId(final Long memberId) {
@@ -215,12 +218,13 @@ public class MemberServiceImpl implements MemberService {
   }
 
   @Override
-  public Long checkMemberAuthenticationCode(String code) {
+  public String checkMemberAuthenticationCode(String code) {
     Long memberId = getCodeCache().get(code, Long.class);
     if (memberId == null) {
       throw new MemberException.CodeNotFoundException();
     }
-    return memberId;
+    ExtensionKey key = encryptService.getKey();
+    return key.encrypt(memberId);
   }
 
   private Cache getCodeCache() {

--- a/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
@@ -38,6 +38,6 @@ public interface MemberService {
 
   String makeMemberAuthenticationCode(Long memberId);
 
-  Long checkMemberAuthenticationCode(String code);
+  String checkMemberAuthenticationCode(String code);
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
@@ -37,4 +37,7 @@ public interface MemberService {
   void updateNotificationSettings(Long memberId, String timezone, String fcmToken);
 
   String makeMemberAuthenticationCode(Long memberId);
+
+  Long checkMemberAuthenticationCode(String code);
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
+++ b/pickly-service/src/main/java/org/pickly/service/member/service/interfaces/MemberService.java
@@ -35,4 +35,6 @@ public interface MemberService {
   MemberProfileDTO getMemberIdByToken(String token);
 
   void updateNotificationSettings(Long memberId, String timezone, String fcmToken);
+
+  String makeMemberAuthenticationCode(Long memberId);
 }


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #258 

<br>

## 🔨 작업 사항 (필수)

-  로컬 캐시 설정 : TTL 5분
-  인증코드 발급 API : 사용자에 매칭되는 값. 4글자
-  인증코드 확인 API : 인증에 성공하면 캐시에서 삭제. response로 암호화된 PK값 전송

<br>

## ⚡️ 관심 리뷰 (선택)

- ConcurrentHashMap은 TTL을 따로 제공하지 않으며, [스프링 공식 문서에도 직접 구현하는 것을 권장](https://docs.spring.io/spring-framework/reference/integration/cache/specific-config.html)하고 있습니다. 따라서 아래 첨부한 레퍼런스를 보고 만료 기한이 있는 ConcurrentMapCache를 만들어 사용했으니 참고해주세요! 

<br>

## ✏️ 레퍼런스

- 캐시매니저에 TTL 설정 : https://dallog.github.io/optimizing-external-calendar-api-calling-with-spring-local-cache/
