### PR TITLE
[bug] member profile 생성시 nickname NPE 수정

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/domain/member/service/MemberReadService.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/service/MemberReadService.java
@@ -41,10 +41,14 @@ public class MemberReadService {
 
   public void isValidNickname(Member member, String newNickname) {
     if (
-        !member.getNickname().equals(newNickname) && existsByNickname(newNickname)
+        checkIsNewNickname(member, newNickname) && existsByNickname(newNickname)
     ) {
       throw new MemberException.NicknameDuplicateException();
     }
+  }
+
+  public boolean checkIsNewNickname(Member member, String newNickname) {
+    return member.getNickname() != null && !member.getNickname().equals(newNickname);
   }
 
   public List<SearchMemberResultResDTO> searchMemberByKeywords(String keyword, Long memberId,


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #275 

<br>

## 🔨 작업 사항 (필수)

- 멤버 닉네임 중복 체크시, null이 아닌 경우에만 기존값과 입력값을 비교하도록 로직 수정

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
