### PR TITLE
[fix] 다수의 카테고리 삭제 시, 하위 북마크가 삭제되지 않는 이슈

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/application/facade/CategoryFacade.java
+++ b/pickly-service/src/main/java/org/pickly/service/application/facade/CategoryFacade.java
@@ -1,6 +1,7 @@
 package org.pickly.service.application.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.pickly.service.domain.bookmark.service.BookmarkWriteService;
 import org.pickly.service.domain.category.controller.request.CategoryOrderNumUpdateReq;
 import org.pickly.service.domain.category.controller.request.CategoryRequestDTO;
 import org.pickly.service.domain.category.controller.request.CategoryUpdateRequestDTO;
@@ -19,6 +20,7 @@ public class CategoryFacade {
   private final CategoryWriteService categoryWriteService;
   private final CategoryReadService categoryReadService;
   private final MemberReadService memberReadService;
+  private final BookmarkWriteService bookmarkWriteService;
 
   public void create(Long memberId, List<CategoryRequestDTO> requests) {
     var member = memberReadService.findById(memberId);
@@ -37,14 +39,18 @@ public class CategoryFacade {
     categoryWriteService.updateOrderNum(requests);
   }
 
+  // FIXME: category 삭제와 bookmark 삭제가 같은 트랜잭션 안에 있어야 함. 그래야 롤백되니까!
+  // FIXME: 근데 여기에 @Transactional 붙이면 더티체킹이 안먹음 ㅠㅠ 아직 원인 파악 몬함
   public void delete(Long categoryId) {
-    var category = categoryReadService.findById(categoryId);
+    Category category = categoryReadService.findById(categoryId);
     categoryWriteService.delete(category);
+    bookmarkWriteService.deleteByCategory(category);
   }
 
   public void delete(List<Long> categoryIds) {
     List<Category> categories = categoryReadService.findByIds(categoryIds);
     categoryWriteService.delete(categories);
+    bookmarkWriteService.deleteByCategory(categories);
   }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/repository/interfaces/BookmarkRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/repository/interfaces/BookmarkRepository.java
@@ -27,6 +27,18 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
       @Param("bookmarkIds") List<Long> bookmarkIds, @Param("deletedAt") LocalDateTime deletedAt
   );
 
+  @Modifying(clearAutomatically = true)
+  @Query("update Bookmark b set b.deletedAt = :deletedAt WHERE b.category.id = :categoryId")
+  void deleteByCategory(
+      @Param("categoryId") Long categoryId, @Param("deletedAt") LocalDateTime deletedAt
+  );
+
+  @Modifying(clearAutomatically = true)
+  @Query("update Bookmark b set b.deletedAt = :deletedAt WHERE b.category.id in :categoryIds")
+  void deleteByCategory(
+      @Param("categoryIds") List<Long> categoryIds, @Param("deletedAt") LocalDateTime deletedAt
+  );
+
   @Transactional
   @Modifying
   @Query("UPDATE Bookmark b SET b.readByUser=True WHERE b.id=:bookmarkId and b.member.id = :memberId")

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/service/BookmarkReadService.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/service/BookmarkReadService.java
@@ -7,7 +7,6 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.pickly.service.common.utils.page.PageRequest;
 import org.pickly.service.common.utils.page.PageResponse;
-import org.pickly.service.common.utils.timezone.TimezoneHandler;
 import org.pickly.service.domain.bookmark.dto.service.BookmarkItemDTO;
 import org.pickly.service.domain.bookmark.dto.service.BookmarkPreviewItemDTO;
 import org.pickly.service.domain.bookmark.entity.Bookmark;
@@ -22,13 +21,8 @@ import org.pickly.service.domain.member.exception.MemberException;
 import org.pickly.service.domain.member.repository.interfaces.MemberRepository;
 import org.pickly.service.domain.member.service.MemberReadService;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -158,21 +152,6 @@ public class BookmarkReadService {
             Bookmark::getMember, LinkedHashMap::new, Collectors.toList()
         )
     );
-  }
-
-  /**
-   * @param categoryId
-   * @description : 카테고리 삭제시 해당 카테고리에 속한 북마크 삭제
-   */
-  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
-  public void findBookmarkByCategoryIdAndDelete(final Long categoryId) {
-    PageRequest pageRequest = new PageRequest(null, 15);
-    LocalDateTime now = TimezoneHandler.getUTCnow();
-    List<Bookmark> bookmarks = bookmarkQueryRepository.findBookmarkByCategoryId(pageRequest,
-        categoryId);
-    List<Long> bookmarkIds = bookmarks.stream().map(Bookmark::getId).toList();
-    bookmarkRepository.deleteBookmarksByIds(bookmarkIds, now);
   }
 
   public Long countByMemberId(Long memberId) {

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/service/BookmarkWriteService.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/service/BookmarkWriteService.java
@@ -1,10 +1,14 @@
 package org.pickly.service.domain.bookmark.service;
 
 import lombok.RequiredArgsConstructor;
+import org.pickly.service.common.utils.base.BaseEntity;
+import org.pickly.service.common.utils.timezone.TimezoneHandler;
 import org.pickly.service.domain.bookmark.entity.Bookmark;
+import org.pickly.service.domain.bookmark.repository.interfaces.BookmarkQueryRepository;
 import org.pickly.service.domain.bookmark.repository.interfaces.BookmarkRepository;
 import org.pickly.service.domain.bookmark.service.dto.BookmarkUpdateReqDTO;
 import org.pickly.service.domain.category.entity.Category;
+import org.pickly.service.domain.member.entity.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +22,7 @@ public class BookmarkWriteService {
 
   private final BookmarkReadService bookmarkReadService;
   private final BookmarkRepository bookmarkRepository;
+  private final BookmarkQueryRepository bookmarkQueryRepository;
 
   public void like(Long bookmarkId) {
     var bookmark = bookmarkReadService.findById(bookmarkId);
@@ -48,6 +53,21 @@ public class BookmarkWriteService {
         request.getReadByUser(),
         request.getVisibility()
     );
+  }
+
+  public void deleteByCategory(final Category category) {
+    Member author = category.getMember();
+    LocalDateTime now = TimezoneHandler.getNowInTimezone(author.getTimezone());
+    bookmarkRepository.deleteByCategory(category.getId(), now);
+  }
+
+  public void deleteByCategory(final List<Category> categories) {
+    if (!categories.isEmpty()) {
+      Member author = categories.get(0).getMember();
+      LocalDateTime now = TimezoneHandler.getNowInTimezone(author.getTimezone());
+      List<Long> categoryIds = categories.stream().map(BaseEntity::getId).toList();
+      bookmarkRepository.deleteByCategory(categoryIds, now);
+    }
   }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/domain/category/controller/request/CategoryRequestDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/category/controller/request/CategoryRequestDTO.java
@@ -1,14 +1,14 @@
 package org.pickly.service.domain.category.controller.request;
 
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 import org.pickly.service.common.utils.validator.emoji.EmojiCheck;
 
 public record CategoryRequestDTO(
-    @NotEmpty(message = "카테고리 이름을 입력해주세요.")
+    @NotBlank(message = "카테고리 이름을 입력해주세요.")
     String name,
 
     @EmojiCheck
-    @NotEmpty(message = "카테고리 emoji를 입력해주세요.")
+    @NotBlank(message = "카테고리 emoji를 입력해주세요.")
     String emoji
 ){
 }

--- a/pickly-service/src/main/java/org/pickly/service/domain/category/service/CategoryWriteService.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/category/service/CategoryWriteService.java
@@ -9,7 +9,6 @@ import org.pickly.service.domain.category.entity.Category;
 import org.pickly.service.domain.category.exception.CategoryException;
 import org.pickly.service.domain.category.repository.interfaces.CategoryJdbcRepository;
 import org.pickly.service.domain.member.entity.Member;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,7 +22,6 @@ import java.util.List;
 public class CategoryWriteService {
 
   private final CategoryJdbcRepository categoryJdbcRepository;
-  private final ApplicationEventPublisher eventPublisher;
 
   public void create(Member member, List<CategoryRequestDTO> requests, int nextOrderNum) {
     List<Category> categories = new ArrayList<>();
@@ -50,7 +48,6 @@ public class CategoryWriteService {
 
   public void delete(Category category) {
     category.delete();
-    eventPublisher.publishEvent(category.getId());
   }
 
   public void delete(List<Category> categories) {


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #278 

<br>

## 🔨 작업 사항 (필수)

- 다수의 카테고리 삭제 메서드에 하위 북마크 삭제 로직 추가

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 트랜잭션, 더티체킹, 롤백 관련 이슈 (#280 )
