### PR TITLE
[fix] 익스텐션 인증코드 일치시, 캐시에서 삭제

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/domain/member/service/MemberWriteService.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/service/MemberWriteService.java
@@ -1,9 +1,9 @@
 package org.pickly.service.domain.member.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.pickly.service.common.config.CacheConfig;
 import org.pickly.service.common.utils.encrypt.EncryptService;
-import org.pickly.service.common.utils.encrypt.ExtensionKey;
 import org.pickly.service.domain.member.entity.Member;
 import org.pickly.service.domain.member.exception.MemberException;
 import org.pickly.service.domain.member.repository.interfaces.MemberRepository;
@@ -15,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Random;
 
+@Slf4j
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -56,14 +57,14 @@ public class MemberWriteService {
   }
 
   public String checkMemberAuthenticationCode(String code) {
-    Long memberId = getCodeCache().get(code, Long.class);
-    if (memberId == null) {
+    Cache cache = getCodeCache();
+    Long memberId = cache.get(code, Long.class);
+    if (memberId != null) {
+      cache.evict(code);
+      return String.valueOf(memberId);
+    } else {
       throw new MemberException.CodeNotFoundException();
     }
-    ExtensionKey key = encryptService.getKey();
-    String result = key.encrypt(memberId);
-    getCodeCache().evict(key);
-    return result;
   }
 
   private Cache getCodeCache() {


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #279 

<br>

## 🔨 작업 사항 (필수)

- 확인된 인증코드는 캐시에서 삭제하고, 다시 제출할 경우 에러를 반환한다.

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
