### PR TITLE
[fix] 특정 유저의 북마크 조회 API에 로그인 유저 ID 포함

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/application/controller/BookmarkController.java
+++ b/pickly-service/src/main/java/org/pickly/service/application/controller/BookmarkController.java
@@ -24,7 +24,6 @@ import org.pickly.service.domain.bookmark.controller.response.BookmarkRes;
 import org.pickly.service.domain.bookmark.dto.service.BookmarkItemDTO;
 import org.pickly.service.domain.bookmark.dto.service.BookmarkPreviewItemDTO;
 import org.pickly.service.domain.bookmark.entity.Bookmark;
-import org.pickly.service.domain.bookmark.entity.Visibility;
 import org.pickly.service.domain.bookmark.service.BookmarkReadService;
 import org.pickly.service.domain.bookmark.service.BookmarkWriteService;
 import org.springframework.http.HttpStatus;
@@ -93,14 +92,14 @@ public class BookmarkController {
       @Parameter(name = "memberId", description = "유저 ID 값", example = "1", required = true)
       @Positive(message = "유저 ID는 양수입니다.") @PathVariable final Long memberId,
 
+      @Parameter(name = "loginId", description = "현재 로그인 유저 ID 값", example = "1", required = true)
+      @Positive(message = "유저 ID는 양수입니다.") @RequestParam final Long loginId,
+
       @Parameter(name = "categoryId", description = "카테고리 ID 값. 필터링 필요 없으면 Null", example = "1")
       @RequestParam(required = false) final Long categoryId,
 
       @Parameter(name = "readByUser", description = "유저의 읽음 여부. 필터링 필요 없으면 Null", example = "true")
       @RequestParam(required = false) final Boolean readByUser,
-
-      @Parameter(name = "visibility", description = "북마크 공개 범위", example = "SCOPE_PUBLIC")
-      @RequestParam(required = false) final Visibility visibility,
 
       @Parameter(description = "커서 ID 값 :: default value = null", example = "1")
       @RequestParam(required = false) final Long cursorId,
@@ -109,8 +108,8 @@ public class BookmarkController {
       @RequestParam(required = false) final Integer pageSize
   ) {
     PageRequest pageRequest = new PageRequest(cursorId, pageSize);
-    return bookmarkReadService.findMemberBookmarks(
-        pageRequest, memberId, categoryId, readByUser, visibility
+    return bookmarkFacade.findMemberBookmarks(
+        pageRequest, memberId, loginId, categoryId, readByUser
     );
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/application/facade/BookmarkFacade.java
+++ b/pickly-service/src/main/java/org/pickly/service/application/facade/BookmarkFacade.java
@@ -1,21 +1,28 @@
 package org.pickly.service.application.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.pickly.service.common.utils.page.PageRequest;
+import org.pickly.service.common.utils.page.PageResponse;
 import org.pickly.service.common.utils.timezone.TimezoneHandler;
 import org.pickly.service.domain.bookmark.controller.request.BookmarkCreateReq;
+import org.pickly.service.domain.bookmark.dto.service.BookmarkPreviewItemDTO;
 import org.pickly.service.domain.bookmark.entity.Bookmark;
 import org.pickly.service.domain.bookmark.service.BookmarkReadService;
 import org.pickly.service.domain.bookmark.service.BookmarkWriteService;
 import org.pickly.service.domain.bookmark.service.dto.BookmarkInfoDTO;
 import org.pickly.service.domain.bookmark.service.dto.BookmarkUpdateReqDTO;
 import org.pickly.service.domain.category.service.CategoryReadService;
+import org.pickly.service.domain.comment.service.CommentReadService;
 import org.pickly.service.domain.comment.service.CommentWriteService;
+import org.pickly.service.domain.friend.entity.Relationship;
+import org.pickly.service.domain.friend.service.FriendReadService;
 import org.pickly.service.domain.member.service.MemberReadService;
 import org.pickly.service.domain.notification.service.NotificationWriteService;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -24,9 +31,11 @@ public class BookmarkFacade {
   private final BookmarkWriteService bookmarkWriteService;
   private final BookmarkReadService bookmarkReadService;
   private final CategoryReadService categoryReadService;
+  private final CommentReadService commentReadService;
   private final CommentWriteService commentWriteService;
   private final NotificationWriteService notificationWriteService;
   private final MemberReadService memberReadService;
+  private final FriendReadService friendReadService;
 
   public Bookmark create(BookmarkCreateReq request) {
     var category = categoryReadService.findById(request.getCategoryId());
@@ -61,6 +70,34 @@ public class BookmarkFacade {
     var category = categoryReadService.findById(request.getCategoryId());
 
     bookmarkWriteService.update(bookmark, category, request);
+  }
+
+  public PageResponse<BookmarkPreviewItemDTO> findMemberBookmarks(
+      final PageRequest pageRequest, final Long memberId, final Long loginId,
+      final Long categoryId, final Boolean readByUser
+  ) {
+    memberReadService.existsById(memberId);
+    memberReadService.existsById(loginId);
+
+    Relationship relationship = checkRelationShip(loginId, memberId);
+    List<Bookmark> bookmarks = bookmarkReadService.findMemberBookmarks(
+        pageRequest, memberId, relationship, categoryId, readByUser
+    );
+
+    Map<Long, Long> bookmarkCommentCntMap = commentReadService.getBookmarkCommentCnt(memberId);
+
+    return bookmarkReadService.makeResponse(
+        pageRequest.getPageSize(), bookmarks, bookmarkCommentCntMap
+    );
+  }
+
+  private Relationship checkRelationShip(Long loginId, Long memberId) {
+    if (memberId.equals(loginId)) {
+      return Relationship.ME;
+    }
+
+    boolean isFriend = friendReadService.checkUsersAreFriend(loginId, memberId);
+    return (isFriend) ? Relationship.FRIEND : Relationship.OTHERS;
   }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/repository/impl/BookmarkQueryRepositoryImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/repository/impl/BookmarkQueryRepositoryImpl.java
@@ -29,7 +29,7 @@ public class BookmarkQueryRepositoryImpl implements BookmarkQueryRepository {
   @Override
   public List<Bookmark> findBookmarks(
       PageRequest pageRequest, Long memberId, Long categoryId, Boolean isUserLike,
-      Boolean readByUser, Visibility visibility
+      Boolean readByUser, List<Visibility> visibilities
   ) {
     Long cursorId = (Long) pageRequest.getCursorId();
     Integer pageSize = pageRequest.getPageSize();
@@ -41,7 +41,7 @@ public class BookmarkQueryRepositoryImpl implements BookmarkQueryRepository {
             eqCategoryId(categoryId),
             eqIsUserLike(isUserLike),
             eqReadByUser(readByUser),
-            eqVisibility(visibility),
+            inVisibility(visibilities),
             notDeleted()
         )
         .orderBy(bookmark.id.desc())
@@ -130,11 +130,11 @@ public class BookmarkQueryRepositoryImpl implements BookmarkQueryRepository {
     return bookmark.isUserLike.eq(isUserLike);
   }
 
-  private BooleanExpression eqVisibility(final Visibility visibility) {
-    if (visibility == null) {
+  private BooleanExpression inVisibility(final List<Visibility> visibilities) {
+    if (visibilities == null) {
       return null;
     }
-    return bookmark.visibility.eq(visibility);
+    return bookmark.visibility.in(visibilities);
   }
 
   private BooleanExpression notDeleted() {

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/repository/interfaces/BookmarkQueryRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/repository/interfaces/BookmarkQueryRepository.java
@@ -1,14 +1,15 @@
 package org.pickly.service.domain.bookmark.repository.interfaces;
 
-import java.util.List;
+import org.pickly.service.common.utils.page.PageRequest;
 import org.pickly.service.domain.bookmark.entity.Bookmark;
 import org.pickly.service.domain.bookmark.entity.Visibility;
-import org.pickly.service.common.utils.page.PageRequest;
+
+import java.util.List;
 
 public interface BookmarkQueryRepository {
 
   List<Bookmark> findBookmarks(PageRequest pageRequest, Long memberId, Long categoryId,
-                               Boolean isUserLike, Boolean readByUser, Visibility visibility);
+                               Boolean isUserLike, Boolean readByUser, List<Visibility> visibilities);
 
   long count(Long memberId, Boolean isUserLike);
 

--- a/pickly-service/src/main/java/org/pickly/service/domain/comment/service/CommentReadService.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/comment/service/CommentReadService.java
@@ -1,7 +1,6 @@
 package org.pickly.service.domain.comment.service;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.pickly.service.domain.comment.entity.Comment;
 import org.pickly.service.domain.comment.exception.CommentException;
 import org.pickly.service.domain.comment.repository.interfaces.CommentQueryRepository;
@@ -12,8 +11,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -40,6 +39,10 @@ public class CommentReadService {
   public Comment findById(final Long id) {
     return commentRepository.findByIdAndDeletedAtNull(id)
         .orElseThrow(CommentException.CommentNotFoundException::new);
+  }
+
+  public Map<Long, Long> getBookmarkCommentCnt(final Long memberId) {
+    return commentQueryRepository.findBookmarkCommentCntByMember(memberId);
   }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/domain/friend/entity/Relationship.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/friend/entity/Relationship.java
@@ -1,0 +1,12 @@
+package org.pickly.service.domain.friend.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum Relationship {
+
+  ME,
+  FRIEND,
+  OTHERS;
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/domain/friend/service/FriendReadService.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/friend/service/FriendReadService.java
@@ -41,6 +41,12 @@ public class FriendReadService {
     }
   }
 
+  public boolean checkUsersAreFriend(final Long loginId, final Long memberId) {
+    return
+        friendRepository.existsByFollowerIdAndFolloweeId(loginId, memberId)
+        || friendRepository.existsByFollowerIdAndFolloweeId(memberId, loginId);
+  }
+
   public Friend findFollowerById(final Long followerId, final Long memberId) {
     return friendRepository.findByFollowerIdAndFolloweeId(followerId, memberId)
         .orElseThrow(FriendException.FriendNotFoundException::new);


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #277 

<br>

## 🔨 작업 사항 (필수)

- 로그인 유저와 요청 유저 사이의 관계를 기반으로, 북마크 공개 범위 필터링 로직 추가
  - 로그인 유저 == 요청 유저 : 전체공개, 비공개, 친구 공개 모두 리턴
  - 로그인 유저와 요청 유저가 친구 : 전체공개, 비공개 리턴
  - 로그인 유저와 요청 유저가 남 : 전체공개 리턴

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
