### PR TITLE
[fix] @Transactional이 붙었는데 더티체킹이 동작하지 않는 이슈 수정

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/application/facade/CategoryFacade.java
+++ b/pickly-service/src/main/java/org/pickly/service/application/facade/CategoryFacade.java
@@ -10,6 +10,7 @@ import org.pickly.service.domain.category.service.CategoryReadService;
 import org.pickly.service.domain.category.service.CategoryWriteService;
 import org.pickly.service.domain.member.service.MemberReadService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -39,14 +40,14 @@ public class CategoryFacade {
     categoryWriteService.updateOrderNum(requests);
   }
 
-  // FIXME: category 삭제와 bookmark 삭제가 같은 트랜잭션 안에 있어야 함. 그래야 롤백되니까!
-  // FIXME: 근데 여기에 @Transactional 붙이면 더티체킹이 안먹음 ㅠㅠ 아직 원인 파악 몬함
+  @Transactional
   public void delete(Long categoryId) {
     Category category = categoryReadService.findById(categoryId);
     categoryWriteService.delete(category);
     bookmarkWriteService.deleteByCategory(category);
   }
 
+  @Transactional
   public void delete(List<Long> categoryIds) {
     List<Category> categories = categoryReadService.findByIds(categoryIds);
     categoryWriteService.delete(categories);

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/repository/interfaces/BookmarkRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/repository/interfaces/BookmarkRepository.java
@@ -27,13 +27,13 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
       @Param("bookmarkIds") List<Long> bookmarkIds, @Param("deletedAt") LocalDateTime deletedAt
   );
 
-  @Modifying(clearAutomatically = true)
+  @Modifying
   @Query("update Bookmark b set b.deletedAt = :deletedAt WHERE b.category.id = :categoryId")
   void deleteByCategory(
       @Param("categoryId") Long categoryId, @Param("deletedAt") LocalDateTime deletedAt
   );
 
-  @Modifying(clearAutomatically = true)
+  @Modifying
   @Query("update Bookmark b set b.deletedAt = :deletedAt WHERE b.category.id in :categoryIds")
   void deleteByCategory(
       @Param("categoryIds") List<Long> categoryIds, @Param("deletedAt") LocalDateTime deletedAt


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #280 

<br>

## 🔨 작업 사항 (필수)

- CategoryFacade에 트랜잭션 어노테이션 추가 (북마크, 카테고리 업데이트를 같은 트랜잭션으로)
- 더티체킹 이용을 위해 clearAutomatically 옵션을 false로 변경

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- [이슈 파악 포스팅 ](https://hogwart-scholars.tistory.com/entry/Spring-BootJPA-Transactional%EC%9D%84-%EC%8D%BC%EB%8A%94%EB%8D%B0%EB%8F%84-Dirty-Checking%EC%97%90-%EC%8B%A4%ED%8C%A8%ED%95%9C%EB%8B%A4%EB%A9%B4-feat-clearAutomatically-true)
