### PR TITLE
[feat] 카테고리 이름 글자수 제한 10글자로 변경

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/domain/category/controller/request/CategoryRequestDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/category/controller/request/CategoryRequestDTO.java
@@ -5,7 +5,7 @@ import org.hibernate.validator.constraints.Length;
 import org.pickly.service.common.utils.validator.emoji.EmojiCheck;
 
 public record CategoryRequestDTO(
-    @Length(max = 20, message = "카테고리 이름은 20글자가 최대입니다.")
+    @Length(max = 10, message = "카테고리 이름은 20글자가 최대입니다.")
     @NotBlank(message = "카테고리 이름을 입력해주세요.")
     String name,
 

--- a/pickly-service/src/main/java/org/pickly/service/domain/category/controller/request/CategoryUpdateRequestDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/category/controller/request/CategoryUpdateRequestDTO.java
@@ -6,7 +6,7 @@ import org.pickly.service.common.utils.validator.emoji.EmojiCheck;
 
 public record CategoryUpdateRequestDTO(
 
-    @Length(max = 20, message = "카테고리 이름은 20글자가 최대입니다.")
+    @Length(max = 10, message = "카테고리 이름은 20글자가 최대입니다.")
     @NotEmpty(message = "카테고리 이름을 입력해주세요.")
     String name,
 

--- a/pickly-service/src/main/java/org/pickly/service/domain/category/entity/Category.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/category/entity/Category.java
@@ -21,7 +21,7 @@ public class Category extends BaseEntity {
   @JoinColumn(name = "member_id")
   private Member member;
 
-  @Column(length = 20, nullable = false)
+  @Column(length = 10, nullable = false)
   private String name;
 
   @Column(columnDefinition = "text")


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #290 

<br>

## 🔨 작업 사항 (필수)

- 이름 길이 제한을 20 -> 10글자로 변경

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
