### PR TITLE
[feat] 북마크 관련 API res에 카테고리 이모지 정보 추가

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/common/BookmarkMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/common/BookmarkMapper.java
@@ -19,6 +19,7 @@ public class BookmarkMapper {
         .id(bookmark.getId())
         .categoryId(category.getId())
         .categoryName(category.getName())
+        .categoryEmoji(category.getEmoji())
         .memberId(bookmark.getMember().getId())
         .url(bookmark.getUrl())
         .title(bookmark.getTitle())

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/dto/controller/response/BookmarkRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/dto/controller/response/BookmarkRes.java
@@ -17,6 +17,8 @@ public class BookmarkRes {
 
   private String categoryName;
 
+  private String categoryEmoji;
+
   private Long memberId;
 
   private String url;

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/dto/service/BookmarkItemDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/dto/service/BookmarkItemDTO.java
@@ -20,6 +20,12 @@ public class BookmarkItemDTO {
   @Schema(description = "북마크 원본 URL", example = "https://naver.com/1242")
   private String url;
 
+  @Schema(description = "소속 카테고리 이름", example = "백엔드")
+  private String categoryName;
+
+  @Schema(description = "소속 카테고리 이모지", example = "🤩")
+  private String categoryEmoji;
+
   @Schema(description = "유저가 좋아요 한 북마크인지?", example = "false")
   private Boolean isUserLike;
 
@@ -32,6 +38,8 @@ public class BookmarkItemDTO {
         .bookmarkId(bookmark.getId())
         .title(bookmark.getTitle())
         .url(bookmark.getUrl())
+        .categoryName(bookmark.getCategory().getName())
+        .categoryEmoji(bookmark.getCategory().getEmoji())
         .isUserLike(bookmark.getIsUserLike())
         .build();
   }

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/dto/service/BookmarkPreviewItemDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/dto/service/BookmarkPreviewItemDTO.java
@@ -1,11 +1,12 @@
 package org.pickly.service.domain.bookmark.dto.service;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.time.LocalDate;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import org.pickly.service.domain.bookmark.entity.Bookmark;
+
+import java.time.LocalDate;
 
 @Getter
 @Builder
@@ -23,6 +24,12 @@ public class BookmarkPreviewItemDTO {
 
   @Schema(description = "북마크 미리보기 이미지 URL", example = "https://naver.com/image/1242")
   private String previewImageUrl;
+
+  @Schema(description = "소속 카테고리 이름", example = "백엔드")
+  private String categoryName;
+
+  @Schema(description = "소속 카테고리 이모지", example = "🤩")
+  private String categoryEmoji;
 
   @Schema(description = "유저가 좋아요 한 북마크인지?", example = "false")
   private Boolean isUserLike;
@@ -46,6 +53,8 @@ public class BookmarkPreviewItemDTO {
         .title(bookmark.getTitle())
         .url(bookmark.getUrl())
         .previewImageUrl(bookmark.getPreviewImageUrl())
+        .categoryName(bookmark.getCategory().getName())
+        .categoryEmoji(bookmark.getCategory().getEmoji())
         .isUserLike(bookmark.getIsUserLike())
         .readByUser(bookmark.getReadByUser())
         .commentCnt(commentCnt)

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/repository/impl/BookmarkQueryRepositoryImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/repository/impl/BookmarkQueryRepositoryImpl.java
@@ -16,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.pickly.service.domain.bookmark.entity.QBookmark.bookmark;
+import static org.pickly.service.domain.category.entity.QCategory.category;
 import static org.pickly.service.domain.notification.entity.QNotification.notification;
 
 @Repository
@@ -35,6 +36,8 @@ public class BookmarkQueryRepositoryImpl implements BookmarkQueryRepository {
     Integer pageSize = pageRequest.getPageSize();
     return queryFactory
         .selectFrom(bookmark)
+        .leftJoin(bookmark.category, category)
+        .fetchJoin()
         .where(
             ltCursorId(cursorId),
             eqMemberId(memberId),

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/service/BookmarkReadService.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/service/BookmarkReadService.java
@@ -14,7 +14,6 @@ import org.pickly.service.domain.bookmark.entity.Visibility;
 import org.pickly.service.domain.bookmark.repository.interfaces.BookmarkQueryRepository;
 import org.pickly.service.domain.bookmark.repository.interfaces.BookmarkRepository;
 import org.pickly.service.domain.bookmark.service.dto.BookmarkInfoDTO;
-import org.pickly.service.domain.comment.repository.interfaces.CommentQueryRepository;
 import org.pickly.service.domain.friend.entity.Relationship;
 import org.pickly.service.domain.member.entity.Member;
 import org.pickly.service.domain.member.repository.interfaces.MemberRepository;
@@ -22,7 +21,10 @@ import org.pickly.service.domain.member.service.MemberReadService;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -42,7 +44,6 @@ public class BookmarkReadService {
   private final MemberRepository memberRepository;
   private final BookmarkRepository bookmarkRepository;
   private final BookmarkQueryRepository bookmarkQueryRepository;
-  private final CommentQueryRepository commentQueryRepository;
   private final MemberReadService memberReadService;
 
   public Long countMemberLikes(final Long memberId) {


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #303 

<br>

## 🔨 작업 사항 (필수)

- 아래 API response에 카테고리 정보 (이름, 이모지) 추가
  - 북마크 상세 조회
  - 유저의 북마크 전체 조회
  - 유저가 좋아요 한 북마크 전체 조회
  - 북마크 생성

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
