### PR TITLE
[feat] 북마크 url로 북마크 정보 크롤링하는 API res 변경

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/application/controller/BookmarkController.java
+++ b/pickly-service/src/main/java/org/pickly/service/application/controller/BookmarkController.java
@@ -192,9 +192,8 @@ public class BookmarkController {
     return bookmarkMapper.entityToResponseDto(entity);
   }
 
-  // FIXME: 231026 사용하지 않기로 결정됨
-  @GetMapping("/members/{memberId}/bookmark/title")
-  @Operation(summary = "특정 북마크의 제목을 url로부터 받아온다.")
+  @GetMapping("/members/{memberId}/bookmark/info")
+  @Operation(summary = "특정 북마크의 제목과 썸네일을 url로부터 받아온다.")
   public String getTitleFromUrl(
       @Parameter(name = "memberId", description = "유저 ID 값", example = "1", required = true)
       @Positive(message = "유저 ID는 양수입니다.") @PathVariable final Long memberId,
@@ -253,8 +252,8 @@ public class BookmarkController {
     return bookmarkMapper.entityToResponseDto(entity);
   }
 
-  @GetMapping("/members/bookmark/title/chrome-extension")
-  @Operation(summary = "[크롬 익스텐션] 특정 북마크의 제목을 url로부터 받아온다.")
+  @GetMapping("/members/bookmark/info/chrome-extension")
+  @Operation(summary = "[크롬 익스텐션] 특정 북마크의 제목과 썸네일을 url로부터 받아온다.")
   public String getTitleFromUrlForExtension(
       @Parameter(name = "memberId", description = "암호화된 유저 ID 값", example = "11a9892", required = true)
       @NotBlank(message = "유저 ID를 입력해주세요.") @RequestParam final String memberId,

--- a/pickly-service/src/main/java/org/pickly/service/application/controller/BookmarkController.java
+++ b/pickly-service/src/main/java/org/pickly/service/application/controller/BookmarkController.java
@@ -19,6 +19,7 @@ import org.pickly.service.domain.bookmark.common.BookmarkMapper;
 import org.pickly.service.domain.bookmark.dto.controller.request.BookmarkCreateReq;
 import org.pickly.service.domain.bookmark.dto.controller.request.BookmarkUpdateReq;
 import org.pickly.service.domain.bookmark.dto.controller.request.ExtensionBookmarkReq;
+import org.pickly.service.domain.bookmark.dto.controller.response.BookmarkCrawlInfoRes;
 import org.pickly.service.domain.bookmark.dto.controller.response.BookmarkReadStatusRes;
 import org.pickly.service.domain.bookmark.dto.controller.response.BookmarkRes;
 import org.pickly.service.domain.bookmark.dto.controller.response.CategoryReadStatusRes;
@@ -27,6 +28,7 @@ import org.pickly.service.domain.bookmark.dto.service.BookmarkPreviewItemDTO;
 import org.pickly.service.domain.bookmark.entity.Bookmark;
 import org.pickly.service.domain.bookmark.service.BookmarkReadService;
 import org.pickly.service.domain.bookmark.service.BookmarkWriteService;
+import org.pickly.service.domain.bookmark.vo.BookmarkCrawlInfo;
 import org.pickly.service.domain.bookmark.vo.BookmarkReadStatus;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
@@ -192,16 +194,14 @@ public class BookmarkController {
     return bookmarkMapper.entityToResponseDto(entity);
   }
 
-  @GetMapping("/members/{memberId}/bookmark/info")
+  @GetMapping("/members/bookmark/info")
   @Operation(summary = "특정 북마크의 제목과 썸네일을 url로부터 받아온다.")
-  public String getTitleFromUrl(
-      @Parameter(name = "memberId", description = "유저 ID 값", example = "1", required = true)
-      @Positive(message = "유저 ID는 양수입니다.") @PathVariable final Long memberId,
-
+  public BookmarkCrawlInfoRes getInfoFromUrl(
       @Parameter(name = "url", description = "북마크의 url", example = "http://naver.com", required = true)
       @NotEmpty(message = "북마크의 url을 입력해주세요.") @RequestParam final String url
   ) {
-    return bookmarkReadService.getTitleFromUrl(memberId, url);
+    BookmarkCrawlInfo info = bookmarkReadService.getInfoFromUrl(url);
+    return bookmarkMapper.toResponse(info);
   }
 
   @GetMapping("/categories/{categoryId}/bookmarks")
@@ -250,19 +250,6 @@ public class BookmarkController {
     BookmarkCreateReq createReq = new BookmarkCreateReq(key.decrypt(dto.memberId()), dto);
     Bookmark entity = bookmarkFacade.create(createReq);
     return bookmarkMapper.entityToResponseDto(entity);
-  }
-
-  @GetMapping("/members/bookmark/info/chrome-extension")
-  @Operation(summary = "[크롬 익스텐션] 특정 북마크의 제목과 썸네일을 url로부터 받아온다.")
-  public String getTitleFromUrlForExtension(
-      @Parameter(name = "memberId", description = "암호화된 유저 ID 값", example = "11a9892", required = true)
-      @NotBlank(message = "유저 ID를 입력해주세요.") @RequestParam final String memberId,
-
-      @Parameter(name = "url", description = "북마크의 url", example = "http://naver.com", required = true)
-      @NotEmpty(message = "북마크의 url을 입력해주세요.") @RequestParam final String url
-  ) {
-    ExtensionKey key = encryptService.getKey();
-    return bookmarkReadService.getTitleFromUrl(key.decrypt(memberId), url);
   }
 
   @Operation(

--- a/pickly-service/src/main/java/org/pickly/service/application/facade/BookmarkFacade.java
+++ b/pickly-service/src/main/java/org/pickly/service/application/facade/BookmarkFacade.java
@@ -44,7 +44,7 @@ public class BookmarkFacade {
     var member = memberReadService.findById(request.getMemberId());
 
     BookmarkInfoDTO info = new BookmarkInfoDTO(
-        request.getUrl(), request.getTitle(), request.getThumbnail(), member.getTimezone()
+        request.getUrl(), request.getTitle(), request.getThumbnail()
     );
     Bookmark bookmark = Bookmark.create(
         category, member, info, request.getVisibility()

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/common/BookmarkMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/common/BookmarkMapper.java
@@ -2,11 +2,13 @@ package org.pickly.service.domain.bookmark.common;
 
 import org.pickly.service.common.utils.timezone.TimezoneHandler;
 import org.pickly.service.domain.bookmark.dto.controller.request.BookmarkUpdateReq;
+import org.pickly.service.domain.bookmark.dto.controller.response.BookmarkCrawlInfoRes;
 import org.pickly.service.domain.bookmark.dto.controller.response.BookmarkReadStatusRes;
 import org.pickly.service.domain.bookmark.dto.controller.response.BookmarkRes;
 import org.pickly.service.domain.bookmark.dto.controller.response.CategoryReadStatusRes;
 import org.pickly.service.domain.bookmark.entity.Bookmark;
 import org.pickly.service.domain.bookmark.service.dto.BookmarkUpdateReqDTO;
+import org.pickly.service.domain.bookmark.vo.BookmarkCrawlInfo;
 import org.pickly.service.domain.bookmark.vo.BookmarkReadStatus;
 import org.pickly.service.domain.category.entity.Category;
 import org.springframework.stereotype.Component;
@@ -67,6 +69,10 @@ public class BookmarkMapper {
       result.add(toCategoryReadStatusDto(entry.getKey(), entry.getValue()));
     }
     return result;
+  }
+
+  public BookmarkCrawlInfoRes toResponse(BookmarkCrawlInfo info) {
+    return new BookmarkCrawlInfoRes(info.getTitle(), info.getThumbnail());
   }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/dto/controller/response/BookmarkCrawlInfoRes.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/dto/controller/response/BookmarkCrawlInfoRes.java
@@ -1,0 +1,7 @@
+package org.pickly.service.domain.bookmark.dto.controller.response;
+
+public record BookmarkCrawlInfoRes(
+    String title,
+    String thumbnail
+) {
+}

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/service/BookmarkReadService.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/service/BookmarkReadService.java
@@ -14,6 +14,7 @@ import org.pickly.service.domain.bookmark.entity.Visibility;
 import org.pickly.service.domain.bookmark.repository.interfaces.BookmarkQueryRepository;
 import org.pickly.service.domain.bookmark.repository.interfaces.BookmarkRepository;
 import org.pickly.service.domain.bookmark.service.dto.BookmarkInfoDTO;
+import org.pickly.service.domain.bookmark.vo.BookmarkCrawlInfo;
 import org.pickly.service.domain.bookmark.vo.BookmarkReadStatus;
 import org.pickly.service.domain.friend.entity.Relationship;
 import org.pickly.service.domain.member.entity.Member;
@@ -31,7 +32,6 @@ import java.util.stream.Collectors;
 
 import static org.pickly.service.domain.bookmark.exception.BookmarkException.BookmarkNotFoundException;
 import static org.pickly.service.domain.bookmark.exception.BookmarkException.ForbiddenBookmarkException;
-import static org.pickly.service.domain.member.exception.MemberException.MemberNotFoundException;
 
 @Slf4j
 @Service
@@ -118,22 +118,19 @@ public class BookmarkReadService {
         .orElseThrow(BookmarkNotFoundException::new);
   }
 
-  public String getTitleFromUrl(Long memberId, String url) {
-    Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
-    BookmarkInfoDTO info = scrapOgTagInfo(url, member);
-    return info.getTitle();
+  public BookmarkCrawlInfo getInfoFromUrl(final String url) {
+    BookmarkInfoDTO info = scrapOgTagInfo(url);
+    return new BookmarkCrawlInfo(url, info.getTitle(), info.getPreviewImageUrl());
   }
 
-  public BookmarkInfoDTO scrapOgTagInfo(final String url, final Member member) {
-    BookmarkInfoDTO result = new BookmarkInfoDTO(url);
+  public BookmarkInfoDTO scrapOgTagInfo(final String url) {
     try {
       Document doc = Jsoup.connect(url).get();
 
       String title = doc.select("meta[property=og:title]").attr(CONTENT_ATTR);
       String previewImageUrl = doc.select("meta[property=og:image]").attr(CONTENT_ATTR);
 
-      result.updateTitleAndImage(title, previewImageUrl, member.getTimezone());
-      return result;
+      return new BookmarkInfoDTO(url, title, previewImageUrl);
     } catch (IOException e) {
       throw new ForbiddenBookmarkException();
     }

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/service/dto/BookmarkInfoDTO.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/service/dto/BookmarkInfoDTO.java
@@ -1,43 +1,20 @@
 package org.pickly.service.domain.bookmark.service.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.pickly.service.common.utils.timezone.TimezoneHandler;
-
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 
 @Slf4j
 @Getter
-@AllArgsConstructor
 public class BookmarkInfoDTO {
 
   private String url;
   private String title;
   private String previewImageUrl;
 
-  public BookmarkInfoDTO(String url) {
+  public BookmarkInfoDTO(String url, String title, String previewImageUrl) {
     this.url = url;
-    this.title = null;
-    this.previewImageUrl = null;
-  }
-
-  public BookmarkInfoDTO(String url, String title, String previewImageUrl, String timezone) {
-    this.url = url;
-    this.title = (title == null || title.isBlank()) ? makeTitle(timezone) : title;
+    this.title = (title == null || title.isBlank()) ? url : title;
     this.previewImageUrl = previewImageUrl.isBlank() ? null : previewImageUrl;
-  }
-
-  public void updateTitleAndImage(String title, String previewImageUrl, String timezone) {
-    this.title = title.isBlank() ? makeTitle(timezone) : title;
-    this.previewImageUrl = previewImageUrl.isBlank() ? null : previewImageUrl;
-  }
-
-  private String makeTitle(String timezone) {
-    LocalDateTime now = TimezoneHandler.getNowInTimezone(timezone);
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy년 MM월 dd일 HH시 mm분의 북마크");
-    return now.format(formatter);
   }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/vo/BookmarkCrawlInfo.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/vo/BookmarkCrawlInfo.java
@@ -1,0 +1,16 @@
+package org.pickly.service.domain.bookmark.vo;
+
+import lombok.Getter;
+
+@Getter
+public class BookmarkCrawlInfo {
+
+  private final String title;
+  private final String thumbnail;
+
+  public BookmarkCrawlInfo(String url, String title, String thumbnail) {
+    this.title = (title.isBlank()) ? url : title;
+    this.thumbnail = thumbnail;
+  }
+
+}


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #323

<br>

## 🔨 작업 사항 (필수)

- 크롤링 API res 변경 : title, 썸네일 리턴
- 로직 변경 : title이 없는 경우 url을 사용할 것
- API 정리 : 크롬 익스텐션용 API 삭제, 바뀐 로직을 반영하여 memberId를 request에서 삭제

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
