### PR TITLE
[feat] 휴면 계정 구현

### DIFF
--- a/pickly-service/src/main/java/org/pickly/service/application/controller/MemberController.java
+++ b/pickly-service/src/main/java/org/pickly/service/application/controller/MemberController.java
@@ -155,7 +155,7 @@ public class MemberController {
     FirebaseToken decodedToken = authTokenUtil.validateToken(token);
     Member request = memberMapper.tokenToMember(decodedToken);
 
-    Member member = memberFacade.create(request);
+    Member member = memberFacade.join(request);
     return memberMapper.toResponse(member);
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/application/facade/MemberFacade.java
+++ b/pickly-service/src/main/java/org/pickly/service/application/facade/MemberFacade.java
@@ -7,6 +7,7 @@ import org.pickly.service.domain.friend.service.FriendReadService;
 import org.pickly.service.domain.member.common.MemberMapper;
 import org.pickly.service.domain.member.dto.service.*;
 import org.pickly.service.domain.member.entity.Member;
+import org.pickly.service.domain.member.entity.MemberStatus;
 import org.pickly.service.domain.member.service.MemberReadService;
 import org.pickly.service.domain.member.service.MemberWriteService;
 import org.pickly.service.domain.notification.service.standard.NotificationStandardReadService;
@@ -48,7 +49,8 @@ public class MemberFacade {
 
   private Member login(final String email) {
     Member savedMember = memberReadService.findByEmail(email);
-    savedMember.updateLastLoginAt();
+    MemberStatus status = savedMember.getStatus();
+    status.login();
     return savedMember;
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/application/facade/MemberFacade.java
+++ b/pickly-service/src/main/java/org/pickly/service/application/facade/MemberFacade.java
@@ -30,15 +30,26 @@ public class MemberFacade {
   private final NotificationStandardWriteService notificationStandardWriteService;
 
   @Transactional
-  public Member create(Member member) {
-    var email = member.getEmail();
+  public Member join(Member request) {
+    var email = request.getEmail();
     if (memberReadService.existsByEmail(email)) {
-      return memberReadService.findByEmail(email);
+      return login(email);
     } else {
-      Member savedMember = memberWriteService.create(member);
-      notificationStandardWriteService.create(savedMember);
-      return savedMember;
+      return create(request);
     }
+  }
+
+  @Transactional
+  public Member create(Member request) {
+    Member member = memberWriteService.create(request);
+    notificationStandardWriteService.create(member);
+    return member;
+  }
+
+  private Member login(final String email) {
+    Member savedMember = memberReadService.findByEmail(email);
+    savedMember.updateLastLoginAt();
+    return savedMember;
   }
 
   @Transactional

--- a/pickly-service/src/main/java/org/pickly/service/common/scheduler/SleeperChecker.java
+++ b/pickly-service/src/main/java/org/pickly/service/common/scheduler/SleeperChecker.java
@@ -1,0 +1,27 @@
+package org.pickly.service.common.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import org.pickly.service.domain.member.entity.Member;
+import org.pickly.service.domain.member.service.MemberReadService;
+import org.pickly.service.domain.member.service.MemberWriteService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class SleeperChecker {
+
+  private final MemberReadService memberReadService;
+  private final MemberWriteService memberWriteService;
+
+  @Scheduled(cron = "0 0 0 * * *")
+  public void checkSleepMember() {
+    final LocalDate current = LocalDate.now();
+    List<Member> sleepers = memberReadService.findLongTermInactive(current);
+    memberWriteService.convertToSleeper(sleepers);
+  }
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/domain/bookmark/repository/impl/BookmarkQueryRepositoryImpl.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/bookmark/repository/impl/BookmarkQueryRepositoryImpl.java
@@ -133,6 +133,7 @@ public class BookmarkQueryRepositoryImpl implements BookmarkQueryRepository {
                 ).notExists()
                 .and(bookmark.readByUser.eq(false))
         )
+        .where(bookmark.member.status.isInactive.eq(false))
         .fetch();
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/common/MemberMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/common/MemberMapper.java
@@ -6,11 +6,10 @@ import org.pickly.service.domain.member.dto.controller.request.MemberStatusReq;
 import org.pickly.service.domain.member.dto.controller.response.*;
 import org.pickly.service.domain.member.dto.service.*;
 import org.pickly.service.domain.member.entity.Member;
+import org.pickly.service.domain.member.entity.MemberStatus;
 import org.pickly.service.domain.member.entity.Password;
 import org.pickly.service.domain.notification.entity.NotificationStandard;
 import org.springframework.stereotype.Component;
-
-import java.time.LocalDateTime;
 
 @Component
 public class MemberMapper {
@@ -18,6 +17,7 @@ public class MemberMapper {
   public Member tokenToMember(FirebaseToken token) {
     //TODO: password nullable한 값으로 변경?
     Password password = new Password("test123");
+    MemberStatus status = new MemberStatus();
 
     return Member.builder()
         .username(token.getUid())
@@ -26,7 +26,7 @@ public class MemberMapper {
         .nickname(token.getUid())
         .isHardMode(false)
         .password(password)
-        .lastLoginAt(LocalDateTime.now())
+        .status(status)
         .build();
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/common/MemberMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/common/MemberMapper.java
@@ -26,7 +26,7 @@ public class MemberMapper {
         .nickname(token.getUid())
         .isHardMode(false)
         .password(password)
-        .lastLoiginAt(LocalDateTime.now())
+        .lastLoginAt(LocalDateTime.now())
         .build();
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/common/MemberMapper.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/common/MemberMapper.java
@@ -10,6 +10,8 @@ import org.pickly.service.domain.member.entity.Password;
 import org.pickly.service.domain.notification.entity.NotificationStandard;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDateTime;
+
 @Component
 public class MemberMapper {
 
@@ -24,6 +26,7 @@ public class MemberMapper {
         .nickname(token.getUid())
         .isHardMode(false)
         .password(password)
+        .lastLoiginAt(LocalDateTime.now())
         .build();
   }
 

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/entity/Member.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/entity/Member.java
@@ -68,6 +68,10 @@ public class Member extends BaseEntity {
     this.lastLoiginAt = lastLoiginAt;
   }
 
+  public void updateLastLoginAt() {
+    this.lastLoiginAt = LocalDateTime.now();
+  }
+
   public void updateProfile(String name, String nickname, String profileEmoji) {
     this.name = name;
     this.nickname = nickname;

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/entity/Member.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/entity/Member.java
@@ -45,12 +45,15 @@ public class Member extends BaseEntity {
   @Column(name = "timezone", length = 20)
   private String timezone;
 
+  @Column(name = "last_login_at")
+  private LocalDateTime lastLoiginAt;
+
   @Builder
   public Member(
       Long id, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt,
       String username, Password password, Boolean isHardMode,
       String email, String name, String nickname, String profileEmoji,
-      String fcmToken, String timezone
+      String fcmToken, String timezone, LocalDateTime lastLoiginAt
   ) {
     super(id, createdAt, updatedAt, deletedAt);
     this.username = username;
@@ -62,6 +65,7 @@ public class Member extends BaseEntity {
     this.profileEmoji = profileEmoji;
     this.fcmToken = fcmToken;
     this.timezone = timezone;
+    this.lastLoiginAt = lastLoiginAt;
   }
 
   public void updateProfile(String name, String nickname, String profileEmoji) {

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/entity/Member.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/entity/Member.java
@@ -69,7 +69,7 @@ public class Member extends BaseEntity {
   }
 
   public void updateLastLoginAt() {
-    this.lastLoiginAt = LocalDateTime.now();
+    this.lastLoginAt = LocalDateTime.now();
   }
 
   public void updateProfile(String name, String nickname, String profileEmoji) {

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/entity/Member.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/entity/Member.java
@@ -46,14 +46,14 @@ public class Member extends BaseEntity {
   private String timezone;
 
   @Column(name = "last_login_at")
-  private LocalDateTime lastLoiginAt;
+  private LocalDateTime lastLoginAt;
 
   @Builder
   public Member(
       Long id, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt,
       String username, Password password, Boolean isHardMode,
       String email, String name, String nickname, String profileEmoji,
-      String fcmToken, String timezone, LocalDateTime lastLoiginAt
+      String fcmToken, String timezone, LocalDateTime lastLoginAt
   ) {
     super(id, createdAt, updatedAt, deletedAt);
     this.username = username;
@@ -65,7 +65,7 @@ public class Member extends BaseEntity {
     this.profileEmoji = profileEmoji;
     this.fcmToken = fcmToken;
     this.timezone = timezone;
-    this.lastLoiginAt = lastLoiginAt;
+    this.lastLoginAt = lastLoginAt;
   }
 
   public void updateLastLoginAt() {

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/entity/Member.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/entity/Member.java
@@ -45,15 +45,15 @@ public class Member extends BaseEntity {
   @Column(name = "timezone", length = 20)
   private String timezone;
 
-  @Column(name = "last_login_at")
-  private LocalDateTime lastLoginAt;
+  @Embedded
+  private MemberStatus status;
 
   @Builder
   public Member(
       Long id, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt,
       String username, Password password, Boolean isHardMode,
       String email, String name, String nickname, String profileEmoji,
-      String fcmToken, String timezone, LocalDateTime lastLoginAt
+      String fcmToken, String timezone, MemberStatus status
   ) {
     super(id, createdAt, updatedAt, deletedAt);
     this.username = username;
@@ -65,11 +65,7 @@ public class Member extends BaseEntity {
     this.profileEmoji = profileEmoji;
     this.fcmToken = fcmToken;
     this.timezone = timezone;
-    this.lastLoginAt = lastLoginAt;
-  }
-
-  public void updateLastLoginAt() {
-    this.lastLoginAt = LocalDateTime.now();
+    this.status = status;
   }
 
   public void updateProfile(String name, String nickname, String profileEmoji) {

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/entity/MemberStatus.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/entity/MemberStatus.java
@@ -29,4 +29,8 @@ public class MemberStatus {
     this.isInactive = false;
   }
 
+  public void convertToInactive() {
+    this.isInactive = true;
+  }
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/entity/MemberStatus.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/entity/MemberStatus.java
@@ -29,8 +29,4 @@ public class MemberStatus {
     this.isInactive = false;
   }
 
-  public void convertToInactive() {
-    this.isInactive = true;
-  }
-
 }

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/entity/MemberStatus.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/entity/MemberStatus.java
@@ -1,0 +1,32 @@
+package org.pickly.service.domain.member.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.time.LocalDateTime;
+
+@Embeddable
+public class MemberStatus {
+
+  @Column(name = "last_login_at")
+  private LocalDateTime lastLoginAt;
+
+  @Column(name = "is_inactive")
+  private Boolean isInactive;
+
+  public MemberStatus() {
+    this.lastLoginAt = LocalDateTime.now();
+    this.isInactive = false;
+  }
+
+  public MemberStatus(LocalDateTime lastLoginAt, Boolean isInactive) {
+    this.lastLoginAt = lastLoginAt;
+    this.isInactive = isInactive;
+  }
+
+  public void login() {
+    this.lastLoginAt = LocalDateTime.now();
+    this.isInactive = false;
+  }
+
+}

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/repository/interfaces/MemberRepository.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/repository/interfaces/MemberRepository.java
@@ -2,7 +2,12 @@ package org.pickly.service.domain.member.repository.interfaces;
 
 import org.pickly.service.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -21,4 +26,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   Optional<Member> findByEmailAndDeletedAtIsNull(String email);
 
   Optional<Member> findByEmail(String email);
+
+  List<Member> findByStatusLastLoginAtBefore(LocalDateTime inactiveStandard);
+
+  @Modifying
+  @Query("update Member m set m.status.isInactive = true where m.id in :ids")
+  void convertToSleeper(@Param("ids") List<Long> memberIds);
+
 }

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/service/MemberReadService.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/service/MemberReadService.java
@@ -11,6 +11,8 @@ import org.pickly.service.domain.member.repository.interfaces.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 
@@ -85,6 +87,11 @@ public class MemberReadService {
   public Member findByEmail(String email) {
     return memberRepository.findByEmailAndDeletedAtIsNull(email)
         .orElseThrow(MemberNotFoundException::new);
+  }
+
+  public List<Member> findLongTermInactive(final LocalDate current) {
+    final LocalDateTime inactiveStandard = current.minusMonths(2).atTime(0, 0);
+    return memberRepository.findByStatusLastLoginAtBefore(inactiveStandard);
   }
 
 }

--- a/pickly-service/src/main/java/org/pickly/service/domain/member/service/MemberWriteService.java
+++ b/pickly-service/src/main/java/org/pickly/service/domain/member/service/MemberWriteService.java
@@ -13,6 +13,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Random;
 
 import static org.pickly.service.domain.member.exception.MemberException.CodeNotFoundException;
@@ -68,6 +69,11 @@ public class MemberWriteService {
     } else {
       throw new CodeNotFoundException();
     }
+  }
+
+  public void convertToSleeper(final List<Member> members) {
+    final List<Long> memberIds = members.stream().map(Member::getId).toList();
+    memberRepository.convertToSleeper(memberIds);
   }
 
   private Cache getCodeCache() {

--- a/pickly-service/src/main/resources/data.sql
+++ b/pickly-service/src/main/resources/data.sql
@@ -1,9 +1,9 @@
 INSERT INTO member
-(username, password, is_hard_mode, email, name, nickname, profile_emoji, fcm_token, timezone)
-VALUES ('test', 'helpme', true, 'test@gmail.com', '테스트1', '테스트1', '😎', null, 'UTC'),
-       ('test2', 'ohmygod', false, 'test2@gmail.com', '테스트2', '테스트2', '😳', null, 'UTC'),
-       ('test3', 'ohmygod', false, 'test3@gmail.com', '테스트3', '테스트3', '🫥', null, 'UTC'),
-       ('test4', 'ohmygod', false, 'test4@gmail.com', '테스트4', '테스트4', '😪', null, 'UTC');
+(username, password, is_hard_mode, email, name, nickname, profile_emoji, fcm_token, timezone, last_login_at)
+VALUES ('test', 'helpme', true, 'test@gmail.com', '테스트1', '테스트1', '😎', null, 'UTC', null),
+       ('test2', 'ohmygod', false, 'test2@gmail.com', '테스트2', '테스트2', '😳', null, 'UTC', null),
+       ('test3', 'ohmygod', false, 'test3@gmail.com', '테스트3', '테스트3', '🫥', null, 'UTC', null),
+       ('test4', 'ohmygod', false, 'test4@gmail.com', '테스트4', '테스트4', '😪', null, 'UTC', null);
 
 INSERT INTO block
     (blockee_id, blocker_id, bookmark_id)

--- a/pickly-service/src/main/resources/data.sql
+++ b/pickly-service/src/main/resources/data.sql
@@ -1,9 +1,9 @@
 INSERT INTO member
-(username, password, is_hard_mode, email, name, nickname, profile_emoji, fcm_token, timezone, last_login_at)
-VALUES ('test', 'helpme', true, 'test@gmail.com', '테스트1', '테스트1', '😎', null, 'UTC', null),
-       ('test2', 'ohmygod', false, 'test2@gmail.com', '테스트2', '테스트2', '😳', null, 'UTC', null),
-       ('test3', 'ohmygod', false, 'test3@gmail.com', '테스트3', '테스트3', '🫥', null, 'UTC', null),
-       ('test4', 'ohmygod', false, 'test4@gmail.com', '테스트4', '테스트4', '😪', null, 'UTC', null);
+(username, password, is_hard_mode, email, name, nickname, profile_emoji, fcm_token, timezone, last_login_at, is_inactive)
+VALUES ('test', 'helpme', true, 'test@gmail.com', '테스트1', '테스트1', '😎', null, 'UTC', null, false),
+       ('test2', 'ohmygod', false, 'test2@gmail.com', '테스트2', '테스트2', '😳', null, 'UTC', null, false),
+       ('test3', 'ohmygod', false, 'test3@gmail.com', '테스트3', '테스트3', '🫥', null, 'UTC', null, false),
+       ('test4', 'ohmygod', false, 'test4@gmail.com', '테스트4', '테스트4', '😪', null, 'UTC', null, false);
 
 INSERT INTO block
     (blockee_id, blocker_id, bookmark_id)

--- a/pickly-service/src/main/resources/schema.sql
+++ b/pickly-service/src/main/resources/schema.sql
@@ -24,22 +24,23 @@ END;
 
 create table member
 (
-    id              bigserial
+    id            bigserial
         constraint member_pk
             primary key,
-    username        varchar(80)             not null,
-    password        varchar(80)             not null,
-    is_hard_mode    boolean                 not null,
-    email           varchar(100)            not null,
-    name            varchar(20),
-    nickname        varchar(200),
-    profile_emoji   text,
-    fcm_token       varchar(200),
-    timezone        varchar(20),
+    username      varchar(80)             not null,
+    password      varchar(80)             not null,
+    is_hard_mode  boolean                 not null,
+    email         varchar(100)            not null,
+    name          varchar(20),
+    nickname      varchar(200),
+    profile_emoji text,
+    fcm_token     varchar(200),
+    timezone      varchar(20),
     last_login_at timestamp,
-    created_at      timestamp default now() not null,
-    updated_at      timestamp,
-    deleted_at      timestamp
+    is_inactive   boolean,
+    created_at    timestamp default now() not null,
+    updated_at    timestamp,
+    deleted_at    timestamp
 );
 
 create unique index member_email_uindex

--- a/pickly-service/src/main/resources/schema.sql
+++ b/pickly-service/src/main/resources/schema.sql
@@ -24,21 +24,22 @@ END;
 
 create table member
 (
-    id            bigserial
+    id              bigserial
         constraint member_pk
             primary key,
-    username      varchar(80)             not null,
-    password      varchar(80)             not null,
-    is_hard_mode  boolean                 not null,
-    email         varchar(100)            not null,
-    name          varchar(20),
-    nickname      varchar(200),
-    profile_emoji text,
-    fcm_token     varchar(200),
-    timezone      varchar(20),
-    created_at    timestamp default now() not null,
-    updated_at    timestamp,
-    deleted_at    timestamp
+    username        varchar(80)             not null,
+    password        varchar(80)             not null,
+    is_hard_mode    boolean                 not null,
+    email           varchar(100)            not null,
+    name            varchar(20),
+    nickname        varchar(200),
+    profile_emoji   text,
+    fcm_token       varchar(200),
+    timezone        varchar(20),
+    last_login_at timestamp,
+    created_at      timestamp default now() not null,
+    updated_at      timestamp,
+    deleted_at      timestamp
 );
 
 create unique index member_email_uindex
@@ -273,7 +274,7 @@ create table report
             references member
             on update cascade on delete cascade,
     content     varchar(150)            not null,
-    dtype varchar(31) not null,
+    dtype       varchar(31)             not null,
     created_at  timestamp default now() not null,
     updated_at  timestamp,
     deleted_at  timestamp

--- a/pickly-service/src/test/resources/schema.sql
+++ b/pickly-service/src/test/resources/schema.sql
@@ -24,22 +24,23 @@ END;
 
 create table member
 (
-    id              bigserial
+    id            bigserial
         constraint member_pk
             primary key,
-    username        varchar(80)             not null,
-    password        varchar(80)             not null,
-    is_hard_mode    boolean                 not null,
-    email           varchar(100)            not null,
-    name            varchar(20),
-    nickname        varchar(200),
-    profile_emoji   text,
-    fcm_token       varchar(200),
-    timezone        varchar(20),
+    username      varchar(80)             not null,
+    password      varchar(80)             not null,
+    is_hard_mode  boolean                 not null,
+    email         varchar(100)            not null,
+    name          varchar(20),
+    nickname      varchar(200),
+    profile_emoji text,
+    fcm_token     varchar(200),
+    timezone      varchar(20),
     last_login_at timestamp,
-    created_at      timestamp default now() not null,
-    updated_at      timestamp,
-    deleted_at      timestamp
+    is_inactive   boolean,
+    created_at    timestamp default now() not null,
+    updated_at    timestamp,
+    deleted_at    timestamp
 );
 
 create unique index member_email_uindex


### PR DESCRIPTION
## 📌 개요 (필수)

- resolve #340
<br>

## 🔨 작업 사항 (필수)

-  마지막 로그인 시간 기록 기능 구현
-  2개월 이상 로그인 하지 않은 유저는 휴면 계정으로 전환 (스케줄러)
-  휴면 유저에게는 알림을 보내지 않게 처리
- member 테이블에 휴면 계정 판단 필드, 마지막 로그인 날짜 필드 추가
- schema.sql, data.sql 업데이트

<br>

## ⚡️ 관심 리뷰 (선택)

- 특별히 확인 받고 싶은 내용을 적어주세요. 

<br>

## 🌱 연관 내용 (선택)

- 관련 있는 내용, 또는 앞으로 고려할 내용을 적어주세요.    
